### PR TITLE
Expose remove_entry on LinkedHashMap and LruCache

### DIFF
--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -389,6 +389,18 @@ where
     }
 
     #[inline]
+    pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        match self.raw_entry_mut().from_key(&k) {
+            RawEntryMut::Occupied(occupied) => Some(occupied.remove_entry()),
+            RawEntryMut::Vacant(_) => None,
+        }
+    }
+
+    #[inline]
     pub fn pop_front(&mut self) -> Option<(K, V)> {
         if self.is_empty() {
             return None;

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -107,6 +107,15 @@ where
     }
 
     #[inline]
+    pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.map.remove_entry(k)
+    }
+
+    #[inline]
     pub fn capacity(&self) -> usize {
         self.max_size
     }


### PR DESCRIPTION
This is useful if you need to remove an item from the map while it's in use.