### PR TITLE
Making the deserialization for LinkedHashMap generic for build hasher type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
+fxhash = "0.2.1"

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "serde_impl")]
 
+use fxhash::FxBuildHasher;
 use hashlink::{LinkedHashMap, LinkedHashSet};
 use serde_test::{assert_tokens, Token};
 
@@ -13,6 +14,35 @@ fn map_serde_tokens_empty() {
 #[test]
 fn map_serde_tokens() {
     let mut map = LinkedHashMap::new();
+    map.insert('a', 10);
+    map.insert('b', 20);
+    map.insert('c', 30);
+
+    assert_tokens(
+        &map,
+        &[
+            Token::Map { len: Some(3) },
+            Token::Char('a'),
+            Token::I32(10),
+            Token::Char('b'),
+            Token::I32(20),
+            Token::Char('c'),
+            Token::I32(30),
+            Token::MapEnd,
+        ],
+    );
+}
+
+#[test]
+fn map_serde_tokens_empty_generic() {
+    let map = LinkedHashMap::<char, u32>::new();
+
+    assert_tokens(&map, &[Token::Map { len: Some(0) }, Token::MapEnd]);
+}
+
+#[test]
+fn map_serde_tokens_generic() {
+    let mut map = LinkedHashMap::with_hasher(FxBuildHasher::default());
     map.insert('a', 10);
     map.insert('b', 20);
     map.insert('c', 30);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -35,7 +35,7 @@ fn map_serde_tokens() {
 
 #[test]
 fn map_serde_tokens_empty_generic() {
-    let map = LinkedHashMap::<char, u32>::new();
+    let map = LinkedHashMap::<char, u32, FxBuildHasher>::with_hasher(FxBuildHasher::default());
 
     assert_tokens(&map, &[Token::Map { len: Some(0) }, Token::MapEnd]);
 }


### PR DESCRIPTION
Changing deserialization impl from LinkedHashMap<K, V> to LinkedHashMap<K, V, S>