### PR TITLE
Upgrade hashbrown to 0.11.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
-hashbrown = "0.9.0"
+hashbrown = "0.11.2"
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This avoids duplicate crate dependencies in packages that depend both on
hashlink and on other crates that pull in more recent versions of
hashbrown.