### PR TITLE
feat: merge all ritelinked changes to hashlink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,26 @@ license = "MIT OR Apache-2.0"
 circle-ci = { repository = "kyren/hashlink", branch = "master" }
 
 [features]
-serde_impl = ["serde"]
+default = ["ahash", "inline-more", "lru"]
+
+ahash-compile-time-rng = ["ahash_/compile-time-rng"]
+
+ahash = [ "ahash_", "hashbrown/ahash" ]
+serde = [ "serde_", "hashbrown/serde" ]
+inline-more = [ "hashbrown/inline-more" ]
+
+amortized = ["griddle"]
+ahash-amortized = [ "ahash", "amortized", "griddle/ahash" ]
+serde-amortized = [ "serde", "amortized", "griddle/serde" ]
+inline-more-amortized = [ "inline-more", "amortized", "griddle/inline-more" ]
+
+lru = []
 
 [dependencies]
-hashbrown = "0.11.0"
-serde = { version = "1.0", optional = true }
+ahash_ = { version = "0.7", default-features = false, optional = true, package = "ahash" }
+hashbrown = { version = "0.11", default-features = false }
+griddle = { version = "0.5.1", default-features = false, optional = true }
+serde_ = { version = "1.0", default-features = false, optional = true, package = "serde" }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,30 @@
-pub mod linked_hash_map;
-pub mod linked_hash_set;
+#![no_std]
+
+extern crate alloc;
+
+mod map;
+mod set;
+
+pub mod linked_hash_map {
+    //! A linked hash map implementation. The order of entries defaults to "insertion order".
+    pub use crate::map::*;
+}
+pub mod linked_hash_set {
+    //! A linked hash set implementation. The order of entries defaults to "insertion order".
+    pub use crate::set::*;
+}
+
+#[cfg(feature = "lru")]
 pub mod lru_cache;
-#[cfg(feature = "serde_impl")]
+
+#[cfg(feature = "serde")]
 pub mod serde;
 
-pub use linked_hash_map::LinkedHashMap;
-pub use linked_hash_set::LinkedHashSet;
-pub use lru_cache::LruCache;
+#[cfg(feature = "lru")]
+pub use crate::lru_cache::LruCache;
+pub use crate::map::LinkedHashMap;
+pub use crate::set::LinkedHashSet;
+
+#[doc(inline)]
+pub use hashbrown::hash_map::DefaultHashBuilder;
+pub use hashbrown::TryReserveError;

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -1,11 +1,11 @@
-use std::{
+use crate::DefaultHashBuilder;
+
+use core::{
     borrow::Borrow,
     fmt,
     hash::{BuildHasher, Hash},
     usize,
 };
-
-use hashbrown::hash_map;
 
 use crate::linked_hash_map::{self, LinkedHashMap};
 
@@ -14,13 +14,13 @@ pub use crate::linked_hash_map::{
     RawOccupiedEntryMut, RawVacantEntryMut, VacantEntry,
 };
 
-pub struct LruCache<K, V, S = hash_map::DefaultHashBuilder> {
+pub struct LruCache<K, V, S = DefaultHashBuilder> {
     map: LinkedHashMap<K, V, S>,
     max_size: usize,
 }
 
 impl<K: Eq + Hash, V> LruCache<K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn new(capacity: usize) -> Self {
         LruCache {
             map: LinkedHashMap::new(),
@@ -31,14 +31,14 @@ impl<K: Eq + Hash, V> LruCache<K, V> {
     /// Create a new unbounded `LruCache` that does not automatically evict entries.
     ///
     /// A simple convenience method that is equivalent to `LruCache::new(usize::MAX)`
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn new_unbounded() -> Self {
         LruCache::new(usize::MAX)
     }
 }
 
 impl<K, V, S> LruCache<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_hasher(capacity: usize, hash_builder: S) -> Self {
         LruCache {
             map: LinkedHashMap::with_hasher(hash_builder),
@@ -46,37 +46,37 @@ impl<K, V, S> LruCache<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn capacity(&self) -> usize {
         self.max_size
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn clear(&mut self) {
         self.map.clear();
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn iter(&self) -> Iter<K, V> {
         self.map.iter()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
         self.map.iter_mut()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn drain(&mut self) -> Drain<K, V> {
         self.map.drain()
     }
@@ -86,7 +86,7 @@ impl<K: Eq + Hash, V, S> LruCache<K, V, S>
 where
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn contains_key<Q>(&mut self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -98,7 +98,7 @@ where
     /// Insert a new value into the `LruCache`.
     ///
     /// If necessary, will remove the value at the front of the LRU list to make room.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         let old_val = self.map.insert(k, v);
         if self.len() > self.capacity() {
@@ -109,7 +109,7 @@ where
 
     /// Get the value for the given key, *without* marking the value as recently used and moving it
     /// to the back of the LRU list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn peek<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -120,7 +120,7 @@ where
 
     /// Get the value for the given key mutably, *without* marking the value as recently used and
     /// moving it to the back of the LRU list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn peek_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -131,7 +131,7 @@ where
 
     /// Retrieve the given key, marking it as recently used and moving it to the back of the LRU
     /// list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get<Q>(&mut self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -142,7 +142,7 @@ where
 
     /// Retrieve the given key, marking it as recently used and moving it to the back of the LRU
     /// list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -163,7 +163,7 @@ where
     /// The returned entry is not automatically moved to the back of the LRU list.  By calling
     /// `Entry::to_back` / `Entry::to_front` you can manually control the position of this entry in
     /// the LRU list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V, S> {
         if self.len() > self.capacity() {
             self.remove_lru();
@@ -174,7 +174,7 @@ where
     /// The constructed raw entry is never automatically moved to the back of the LRU list.  By
     /// calling `Entry::to_back` / `Entry::to_front` you can manually control the position of this
     /// entry in the LRU list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn raw_entry(&self) -> RawEntryBuilder<'_, K, V, S> {
         self.map.raw_entry()
     }
@@ -185,7 +185,7 @@ where
     /// The constructed raw entry is never automatically moved to the back of the LRU list.  By
     /// calling `Entry::to_back` / `Entry::to_front` you can manually control the position of this
     /// entry in the LRU list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn raw_entry_mut(&mut self) -> RawEntryBuilderMut<'_, K, V, S> {
         if self.len() > self.capacity() {
             self.remove_lru();
@@ -193,7 +193,7 @@ where
         self.map.raw_entry_mut()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove<Q>(&mut self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -202,7 +202,7 @@ where
         self.map.remove(k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
@@ -215,7 +215,7 @@ where
     ///
     /// If there are more entries in the `LruCache` than the new capacity will allow, they are
     /// removed.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn set_capacity(&mut self, capacity: usize) {
         for _ in capacity..self.len() {
             self.remove_lru();
@@ -233,7 +233,7 @@ where
 }
 
 impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LruCache<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         LruCache {
             map: self.map.clone(),
@@ -243,7 +243,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LruCache<
 }
 
 impl<K: Eq + Hash, V, S: BuildHasher> Extend<(K, V)> for LruCache<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         for (k, v) in iter {
             self.insert(k, v);
@@ -255,7 +255,7 @@ impl<K, V, S> IntoIterator for LruCache<K, V, S> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> IntoIter<K, V> {
         self.map.into_iter()
     }
@@ -265,7 +265,7 @@ impl<'a, K, V, S> IntoIterator for &'a LruCache<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> Iter<'a, K, V> {
         self.iter()
     }
@@ -275,7 +275,7 @@ impl<'a, K, V, S> IntoIterator for &'a mut LruCache<K, V, S> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> IterMut<'a, K, V> {
         self.iter_mut()
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,8 @@
-use std::{
+use crate::DefaultHashBuilder;
+use crate::TryReserveError;
+
+use alloc::boxed::Box;
+use core::{
     borrow::Borrow,
     cmp::Ordering,
     fmt,
@@ -10,9 +14,11 @@ use std::{
     ptr::{self, NonNull},
 };
 
+#[cfg(not(feature = "amortized"))]
 use hashbrown::{hash_map, HashMap};
 
-pub type TryReserveError = hashbrown::TryReserveError;
+#[cfg(feature = "amortized")]
+use griddle::{hash_map, HashMap};
 
 /// A version of `HashMap` that has a user controllable order for its entries.
 ///
@@ -29,7 +35,7 @@ pub type TryReserveError = hashbrown::TryReserveError;
 /// * Methods that have the word `insert` will insert a new entry ot the back of the list, and if
 ///   that method might replace an entry, that method will *also move that existing entry to the
 ///   back*.
-pub struct LinkedHashMap<K, V, S = hash_map::DefaultHashBuilder> {
+pub struct LinkedHashMap<K, V, S = DefaultHashBuilder> {
     map: HashMap<NonNull<Node<K, V>>, (), NullHasher>,
     // We need to keep any custom hash builder outside of the HashMap so we can access it alongside
     // the entry API without mutable aliasing.
@@ -43,30 +49,21 @@ pub struct LinkedHashMap<K, V, S = hash_map::DefaultHashBuilder> {
     free: Option<NonNull<Node<K, V>>>,
 }
 
-impl<K, V> LinkedHashMap<K, V> {
-    #[inline]
+#[cfg(feature = "ahash")]
+impl<K, V> LinkedHashMap<K, V, DefaultHashBuilder> {
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn new() -> Self {
-        Self {
-            hash_builder: hash_map::DefaultHashBuilder::default(),
-            map: HashMap::with_hasher(NullHasher),
-            values: None,
-            free: None,
-        }
+        Self::default()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            hash_builder: hash_map::DefaultHashBuilder::default(),
-            map: HashMap::with_capacity_and_hasher(capacity, NullHasher),
-            values: None,
-            free: None,
-        }
+        Self::with_capacity_and_hasher(capacity, DefaultHashBuilder::default())
     }
 }
 
 impl<K, V, S> LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_hasher(hash_builder: S) -> Self {
         Self {
             hash_builder,
@@ -76,7 +73,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
         Self {
             hash_builder,
@@ -86,34 +83,34 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn reserve(&mut self, additional: usize) {
         self.map.reserve(additional);
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.map.try_reserve(additional)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn shrink_to_fit(&mut self) {
         self.map.shrink_to_fit();
         unsafe { drop_free_nodes(self.free) };
         self.free = None;
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn clear(&mut self) {
         self.map.clear();
         if let Some(mut values) = self.values {
@@ -127,7 +124,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn iter(&self) -> Iter<K, V> {
         let (head, tail) = if let Some(values) = self.values {
             unsafe {
@@ -146,7 +143,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
         let (head, tail) = if let Some(values) = self.values {
             unsafe {
@@ -165,7 +162,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn drain(&mut self) -> Drain<'_, K, V> {
         unsafe {
             let (head, tail) = if let Some(mut values) = self.values {
@@ -192,24 +189,24 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn keys(&self) -> Keys<K, V> {
         Keys { inner: self.iter() }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn values(&self) -> Values<K, V> {
         Values { inner: self.iter() }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn values_mut(&mut self) -> ValuesMut<K, V> {
         ValuesMut {
             inner: self.iter_mut(),
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn front(&self) -> Option<(&K, &V)> {
         if self.is_empty() {
             return None;
@@ -221,7 +218,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn back(&self) -> Option<(&K, &V)> {
         if self.is_empty() {
             return None;
@@ -233,7 +230,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&K, &mut V) -> bool,
@@ -251,7 +248,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
 
         impl<'a, K, V> DropFilteredValues<'a, K, V> {
-            #[inline]
+            #[cfg_attr(feature = "inline-more", inline)]
             fn drop_later(&mut self, node: NonNull<Node<K, V>>) {
                 unsafe {
                     detach_node(node);
@@ -291,12 +288,12 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         });
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn hasher(&self) -> &S {
         &self.hash_builder
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn capacity(&self) -> usize {
         self.map.capacity()
     }
@@ -307,7 +304,7 @@ where
     K: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V, S> {
         match self.raw_entry_mut().from_key(&key) {
             RawEntryMut::Occupied(occupied) => Entry::Occupied(OccupiedEntry {
@@ -339,7 +336,7 @@ where
         self.raw_entry().from_key(k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -348,7 +345,7 @@ where
         self.get(k).is_some()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -364,7 +361,7 @@ where
     ///
     /// Returns the previously set value, if one existed prior to this call.  After this call,
     /// calling `LinkedHashMap::back` will return a reference to this key / value pair.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(&mut self, k: K, v: V) -> Option<V> {
         match self.raw_entry_mut().from_key(&k) {
             RawEntryMut::Occupied(mut occupied) => {
@@ -382,7 +379,7 @@ where
     /// internal linked list and returns `None`, otherwise, replaces the existing value with the
     /// given value *without* moving the entry in the internal linked list and returns the previous
     /// value.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace(&mut self, k: K, v: V) -> Option<V> {
         match self.raw_entry_mut().from_key(&k) {
             RawEntryMut::Occupied(mut occupied) => Some(occupied.replace_value(v)),
@@ -393,7 +390,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove<Q>(&mut self, k: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -405,7 +402,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove_entry<Q>(&mut self, k: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
@@ -417,7 +414,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn pop_front(&mut self) -> Option<(K, V)> {
         if self.is_empty() {
             return None;
@@ -436,7 +433,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn pop_back(&mut self) -> Option<(K, V)> {
         if self.is_empty() {
             return None;
@@ -459,7 +456,8 @@ where
 
     /// If an entry with this key exists, move it to the front of the list and return a reference to
     /// the value.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_front<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -476,7 +474,8 @@ where
 
     /// If an entry with this key exists, move it to the back of the list and return a reference to
     /// the value.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_back<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -496,7 +495,7 @@ impl<K, V, S> LinkedHashMap<K, V, S>
 where
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn raw_entry(&self) -> RawEntryBuilder<'_, K, V, S> {
         RawEntryBuilder {
             hash_builder: &self.hash_builder,
@@ -504,7 +503,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn raw_entry_mut(&mut self) -> RawEntryBuilderMut<'_, K, V, S> {
         RawEntryBuilderMut {
             hash_builder: &self.hash_builder,
@@ -519,14 +518,14 @@ impl<K, V, S> Default for LinkedHashMap<K, V, S>
 where
     S: Default,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn default() -> Self {
         Self::with_hasher(S::default())
     }
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher + Default> FromIterator<(K, V)> for LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut map = Self::with_capacity_and_hasher(iter.size_hint().0, S::default());
@@ -540,14 +539,14 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map().entries(self).finish()
     }
 }
 
 impl<K: Hash + Eq, V: PartialEq, S: BuildHasher> PartialEq for LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().eq(other)
     }
@@ -558,41 +557,41 @@ impl<K: Hash + Eq, V: Eq, S: BuildHasher> Eq for LinkedHashMap<K, V, S> {}
 impl<K: Hash + Eq + PartialOrd, V: PartialOrd, S: BuildHasher> PartialOrd
     for LinkedHashMap<K, V, S>
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.iter().partial_cmp(other)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn lt(&self, other: &Self) -> bool {
         self.iter().lt(other)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn le(&self, other: &Self) -> bool {
         self.iter().le(other)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn ge(&self, other: &Self) -> bool {
         self.iter().ge(other)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn gt(&self, other: &Self) -> bool {
         self.iter().gt(other)
     }
 }
 
 impl<K: Hash + Eq + Ord, V: Ord, S: BuildHasher> Ord for LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.iter().cmp(other)
     }
 }
 
 impl<K: Hash + Eq, V: Hash, S: BuildHasher> Hash for LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn hash<H: Hasher>(&self, h: &mut H) {
         for e in self.iter() {
             e.hash(h);
@@ -601,7 +600,7 @@ impl<K: Hash + Eq, V: Hash, S: BuildHasher> Hash for LinkedHashMap<K, V, S> {
 }
 
 impl<K, V, S> Drop for LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn drop(&mut self) {
         unsafe {
             if let Some(values) = self.values {
@@ -624,7 +623,7 @@ where
 {
     type Output = V;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn index(&self, index: &'a Q) -> &V {
         self.get(index).expect("no entry found for key")
     }
@@ -636,14 +635,14 @@ where
     S: BuildHasher,
     Q: Eq + Hash + ?Sized,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn index_mut(&mut self, index: &'a Q) -> &mut V {
         self.get_mut(index).expect("no entry found for key")
     }
 }
 
 impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         let mut map = Self::with_hasher(self.hash_builder.clone());
         map.extend(self.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -652,7 +651,7 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LinkedHas
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher> Extend<(K, V)> for LinkedHashMap<K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         for (k, v) in iter {
             self.insert(k, v);
@@ -666,7 +665,7 @@ where
     V: 'a + Copy,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
         for (&k, &v) in iter {
             self.insert(k, v);
@@ -680,7 +679,7 @@ pub enum Entry<'a, K, V, S> {
 }
 
 impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for Entry<'_, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Entry::Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
@@ -695,7 +694,7 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
     ///
     /// If this entry is occupied, this method *moves the occupied entry to the back of the internal
     /// linked list* and returns a reference to the existing value.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn or_insert(self, default: V) -> &'a mut V
     where
         K: Hash,
@@ -712,7 +711,7 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
 
     /// Similar to `Entry::or_insert`, but accepts a function to construct a new value if this entry
     /// is vacant.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V
     where
         K: Hash,
@@ -727,7 +726,7 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn key(&self) -> &K {
         match *self {
             Entry::Occupied(ref entry) => entry.key(),
@@ -735,7 +734,7 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn and_modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut V),
@@ -756,7 +755,7 @@ pub struct OccupiedEntry<'a, K, V> {
 }
 
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for OccupiedEntry<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OccupiedEntry")
             .field("key", self.key())
@@ -766,37 +765,39 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for OccupiedEntry<'_, K, V> {
 }
 
 impl<'a, K, V> OccupiedEntry<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn key(&self) -> &K {
         self.raw_entry.key()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove_entry(self) -> (K, V) {
         self.raw_entry.remove_entry()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get(&self) -> &V {
         self.raw_entry.get()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_mut(&mut self) -> &mut V {
         self.raw_entry.get_mut()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn into_mut(self) -> &'a mut V {
         self.raw_entry.into_mut()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_back(&mut self) {
         self.raw_entry.to_back()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_front(&mut self) {
         self.raw_entry.to_front()
     }
@@ -805,20 +806,20 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     ///
     /// Similarly to `LinkedHashMap::insert`, this moves the existing entry to the back of the
     /// internal linked list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(&mut self, value: V) -> V {
         self.raw_entry.to_back();
         self.raw_entry.replace_value(value)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove(self) -> V {
         self.raw_entry.remove()
     }
 
     /// Similar to `OccupiedEntry::replace_entry`, but *does* move the entry to the back of the
     /// internal linked list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert_entry(mut self, value: V) -> (K, V) {
         self.raw_entry.to_back();
         self.replace_entry(value)
@@ -837,7 +838,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     /// Replaces this entry's key with the key provided to `LinkedHashMap::entry`.
     ///
     /// Does *not* move the entry to the back of the internal linked list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace_key(mut self) -> K {
         mem::replace(self.raw_entry.key_mut(), self.key)
     }
@@ -849,26 +850,26 @@ pub struct VacantEntry<'a, K, V, S> {
 }
 
 impl<K: fmt::Debug, V, S> fmt::Debug for VacantEntry<'_, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VacantEntry").field(self.key()).finish()
     }
 }
 
 impl<'a, K, V, S> VacantEntry<'a, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn key(&self) -> &K {
         &self.key
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn into_key(self) -> K {
         self.key
     }
 
     /// Insert's the key for this vacant entry paired with the given value as a new entry at the
     /// *back* of the internal linked list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(self, value: V) -> &'a mut V
     where
         K: Hash,
@@ -887,7 +888,8 @@ impl<'a, K, V, S> RawEntryBuilder<'a, K, V, S>
 where
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key<Q>(self, k: &Q) -> Option<(&'a K, &'a V)>
     where
         K: Borrow<Q>,
@@ -898,6 +900,7 @@ where
     }
 
     #[inline]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key_hashed_nocheck<Q>(self, hash: u64, k: &Q) -> Option<(&'a K, &'a V)>
     where
         K: Borrow<Q>,
@@ -906,7 +909,8 @@ where
         self.from_hash(hash, move |o| k.eq(o.borrow()))
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_hash(
         self,
         hash: u64,
@@ -951,7 +955,8 @@ impl<'a, K, V, S> RawEntryBuilderMut<'a, K, V, S>
 where
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key<Q>(self, k: &Q) -> RawEntryMut<'a, K, V, S>
     where
         K: Borrow<Q>,
@@ -961,7 +966,8 @@ where
         self.from_key_hashed_nocheck(hash, k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_key_hashed_nocheck<Q>(self, hash: u64, k: &Q) -> RawEntryMut<'a, K, V, S>
     where
         K: Borrow<Q>,
@@ -970,7 +976,8 @@ where
         self.from_hash(hash, move |o| k.eq(o.borrow()))
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn from_hash(
         self,
         hash: u64,
@@ -1022,7 +1029,7 @@ pub enum RawEntryMut<'a, K, V, S> {
 impl<'a, K, V, S> RawEntryMut<'a, K, V, S> {
     /// Similarly to `Entry::or_insert`, if this entry is occupied, it will move the existing entry
     /// to the back of the internal linked list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn or_insert(self, default_key: K, default_val: V) -> (&'a mut K, &'a mut V)
     where
         K: Hash,
@@ -1039,7 +1046,7 @@ impl<'a, K, V, S> RawEntryMut<'a, K, V, S> {
 
     /// Similarly to `Entry::or_insert_with`, if this entry is occupied, it will move the existing
     /// entry to the back of the internal linked list.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn or_insert_with<F>(self, default: F) -> (&'a mut K, &'a mut V)
     where
         F: FnOnce() -> (K, V),
@@ -1058,7 +1065,7 @@ impl<'a, K, V, S> RawEntryMut<'a, K, V, S> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn and_modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut K, &mut V),
@@ -1083,37 +1090,37 @@ pub struct RawOccupiedEntryMut<'a, K, V> {
 }
 
 impl<'a, K, V> RawOccupiedEntryMut<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn key(&self) -> &K {
         self.get_key_value().0
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn key_mut(&mut self) -> &mut K {
         self.get_key_value_mut().0
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn into_key(self) -> &'a mut K {
         self.into_key_value().0
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get(&self) -> &V {
         self.get_key_value().1
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_mut(&mut self) -> &mut V {
         self.get_key_value_mut().1
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn into_mut(self) -> &'a mut V {
         self.into_key_value().1
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_key_value(&self) -> (&K, &V) {
         unsafe {
             let node = *self.entry.key();
@@ -1131,7 +1138,7 @@ impl<'a, K, V> RawOccupiedEntryMut<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn into_key_value(self) -> (&'a mut K, &'a mut V) {
         unsafe {
             let node = *self.entry.into_key();
@@ -1140,7 +1147,8 @@ impl<'a, K, V> RawOccupiedEntryMut<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_back(&mut self) {
         unsafe {
             let node = *self.entry.key_mut();
@@ -1149,7 +1157,8 @@ impl<'a, K, V> RawOccupiedEntryMut<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_front(&mut self) {
         unsafe {
             let node = *self.entry.key_mut();
@@ -1158,7 +1167,7 @@ impl<'a, K, V> RawOccupiedEntryMut<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace_value(&mut self, value: V) -> V {
         unsafe {
             let mut node = *self.entry.key_mut();
@@ -1166,7 +1175,7 @@ impl<'a, K, V> RawOccupiedEntryMut<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace_key(&mut self, key: K) -> K {
         unsafe {
             let mut node = *self.entry.key_mut();
@@ -1174,12 +1183,12 @@ impl<'a, K, V> RawOccupiedEntryMut<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove(self) -> V {
         self.remove_entry().1
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove_entry(self) -> (K, V) {
         let node = self.entry.remove_entry().0;
         unsafe { remove_node(self.free, node) }
@@ -1194,7 +1203,7 @@ pub struct RawVacantEntryMut<'a, K, V, S> {
 }
 
 impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(self, key: K, value: V) -> (&'a mut K, &'a mut V)
     where
         K: Hash,
@@ -1204,7 +1213,7 @@ impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
         self.insert_hashed_nocheck(hash, key, value)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert_hashed_nocheck(self, hash: u64, key: K, value: V) -> (&'a mut K, &'a mut V)
     where
         K: Hash,
@@ -1214,7 +1223,7 @@ impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
         self.insert_with_hasher(hash, key, value, |k| hash_key(hash_builder, k))
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert_with_hasher(
         self,
         hash: u64,
@@ -1243,14 +1252,14 @@ impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
 }
 
 impl<K, V, S> fmt::Debug for RawEntryBuilderMut<'_, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }
 }
 
 impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for RawEntryMut<'_, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             RawEntryMut::Vacant(ref v) => f.debug_tuple("RawEntry").field(v).finish(),
@@ -1260,7 +1269,7 @@ impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for RawEntryMut<'_, K, V, S> {
 }
 
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for RawOccupiedEntryMut<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawOccupiedEntryMut")
             .field("key", self.key())
@@ -1270,14 +1279,14 @@ impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for RawOccupiedEntryMut<'_, K, V> 
 }
 
 impl<K, V, S> fmt::Debug for RawVacantEntryMut<'_, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawVacantEntryMut").finish()
     }
 }
 
 impl<K, V, S> fmt::Debug for RawEntryBuilder<'_, K, V, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }
@@ -1344,7 +1353,7 @@ pub struct Drain<'a, K, V> {
 }
 
 impl<K, V> IterMut<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub(crate) fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             head: self.head.as_ptr(),
@@ -1356,7 +1365,7 @@ impl<K, V> IterMut<'_, K, V> {
 }
 
 impl<K, V> IntoIter<K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub(crate) fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             head: self.head.as_ptr(),
@@ -1368,7 +1377,7 @@ impl<K, V> IntoIter<K, V> {
 }
 
 impl<K, V> Drain<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub(crate) fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             head: self.head.as_ptr(),
@@ -1436,14 +1445,14 @@ where
 }
 
 impl<'a, K, V> Clone for Iter<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         Iter { ..*self }
     }
 }
 
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Iter<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -1454,7 +1463,7 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -1465,7 +1474,7 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -1476,7 +1485,7 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -1485,7 +1494,7 @@ where
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<(&'a K, &'a V)> {
         if self.remaining == 0 {
             None
@@ -1499,7 +1508,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }
@@ -1508,7 +1517,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<(&'a K, &'a mut V)> {
         if self.remaining == 0 {
             None
@@ -1523,7 +1532,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }
@@ -1532,7 +1541,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
 impl<K, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<(K, V)> {
         if self.remaining == 0 {
             return None;
@@ -1546,7 +1555,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }
@@ -1555,7 +1564,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
 impl<'a, K, V> Iterator for Drain<'a, K, V> {
     type Item = (K, V);
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<(K, V)> {
         if self.remaining == 0 {
             return None;
@@ -1570,14 +1579,14 @@ impl<'a, K, V> Iterator for Drain<'a, K, V> {
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }
 }
 
 impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<(&'a K, &'a V)> {
         if self.remaining == 0 {
             None
@@ -1594,7 +1603,7 @@ impl<'a, K, V> DoubleEndedIterator for Iter<'a, K, V> {
 }
 
 impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<(&'a K, &'a mut V)> {
         if self.remaining == 0 {
             None
@@ -1611,7 +1620,7 @@ impl<'a, K, V> DoubleEndedIterator for IterMut<'a, K, V> {
 }
 
 impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<(K, V)> {
         if self.remaining == 0 {
             return None;
@@ -1626,7 +1635,7 @@ impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
 }
 
 impl<'a, K, V> DoubleEndedIterator for Drain<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<(K, V)> {
         if self.remaining == 0 {
             return None;
@@ -1649,7 +1658,7 @@ impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {}
 impl<K, V> ExactSizeIterator for IntoIter<K, V> {}
 
 impl<K, V> Drop for IntoIter<K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn drop(&mut self) {
         for _ in 0..self.remaining {
             unsafe {
@@ -1663,7 +1672,7 @@ impl<K, V> Drop for IntoIter<K, V> {
 }
 
 impl<'a, K, V> Drop for Drain<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn drop(&mut self) {
         for _ in 0..self.remaining {
             unsafe {
@@ -1681,14 +1690,14 @@ pub struct Keys<'a, K, V> {
 }
 
 impl<K: fmt::Debug, V> fmt::Debug for Keys<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, K, V> Clone for Keys<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Keys<'a, K, V> {
         Keys {
             inner: self.inner.clone(),
@@ -1699,26 +1708,26 @@ impl<'a, K, V> Clone for Keys<'a, K, V> {
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a K> {
         self.inner.next().map(|e| e.0)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<&'a K> {
         self.inner.next_back().map(|e| e.0)
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -1729,7 +1738,7 @@ pub struct Values<'a, K, V> {
 }
 
 impl<K, V> Clone for Values<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         Values {
             inner: self.inner.clone(),
@@ -1738,7 +1747,7 @@ impl<K, V> Clone for Values<'_, K, V> {
 }
 
 impl<K, V: fmt::Debug> fmt::Debug for Values<'_, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -1747,26 +1756,26 @@ impl<K, V: fmt::Debug> fmt::Debug for Values<'_, K, V> {
 impl<'a, K, V> Iterator for Values<'a, K, V> {
     type Item = &'a V;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a V> {
         self.inner.next().map(|e| e.1)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<&'a V> {
         self.inner.next_back().map(|e| e.1)
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -1781,7 +1790,7 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.inner.iter()).finish()
     }
@@ -1790,26 +1799,26 @@ where
 impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a mut V> {
         self.inner.next().map(|e| e.1)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 }
 
 impl<'a, K, V> DoubleEndedIterator for ValuesMut<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<&'a mut V> {
         self.inner.next_back().map(|e| e.1)
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for ValuesMut<'a, K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -1819,7 +1828,7 @@ impl<'a, K, V, S> IntoIterator for &'a LinkedHashMap<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> Iter<'a, K, V> {
         self.iter()
     }
@@ -1829,7 +1838,7 @@ impl<'a, K, V, S> IntoIterator for &'a mut LinkedHashMap<K, V, S> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> IterMut<'a, K, V> {
         self.iter_mut()
     }
@@ -1839,7 +1848,7 @@ impl<K, V, S> IntoIterator for LinkedHashMap<K, V, S> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(mut self) -> IntoIter<K, V> {
         unsafe {
             let (head, tail) = if let Some(values) = self.values {
@@ -1878,19 +1887,19 @@ struct NullHasher;
 impl BuildHasher for NullHasher {
     type Hasher = Self;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn build_hasher(&self) -> Self {
         Self
     }
 }
 
 impl Hasher for NullHasher {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn write(&mut self, _bytes: &[u8]) {
         unreachable!("inner map should not be using its built-in hasher")
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn finish(&self) -> u64 {
         unreachable!("inner map should not be using its built-in hasher")
     }
@@ -1902,7 +1911,7 @@ struct ValueLinks<K, V> {
 }
 
 impl<K, V> Clone for ValueLinks<K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         ValueLinks {
             next: self.next,
@@ -1918,7 +1927,7 @@ struct FreeLink<K, V> {
 }
 
 impl<K, V> Clone for FreeLink<K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         FreeLink { next: self.next }
     }
@@ -1937,38 +1946,39 @@ struct Node<K, V> {
 }
 
 impl<K, V> Node<K, V> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn put_entry(&mut self, entry: (K, V)) {
         self.entry.as_mut_ptr().write(entry)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn entry_ref(&self) -> &(K, V) {
         &*self.entry.as_ptr()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn key_ref(&self) -> &K {
         &(*self.entry.as_ptr()).0
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn entry_mut(&mut self) -> &mut (K, V) {
         &mut *self.entry.as_mut_ptr()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     unsafe fn take_entry(&mut self) -> (K, V) {
         self.entry.as_ptr().read()
     }
 }
 
 trait OptNonNullExt<T> {
+    #[allow(clippy::wrong_self_convention)]
     fn as_ptr(self) -> *mut T;
 }
 
 impl<T> OptNonNullExt<T> for Option<NonNull<T>> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn as_ptr(self) -> *mut T {
         match self {
             Some(ptr) => ptr.as_ptr(),
@@ -1978,7 +1988,7 @@ impl<T> OptNonNullExt<T> for Option<NonNull<T>> {
 }
 
 // Allocate a circular list guard node if not present.
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn ensure_guard_node<K, V>(head: &mut Option<NonNull<Node<K, V>>>) {
     if head.is_none() {
         let mut p = NonNull::new_unchecked(Box::into_raw(Box::new(Node {
@@ -1996,7 +2006,7 @@ unsafe fn ensure_guard_node<K, V>(head: &mut Option<NonNull<Node<K, V>>>) {
 }
 
 // Attach the `to_attach` node to the existing circular list *before* `node`.
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn attach_before<K, V>(mut to_attach: NonNull<Node<K, V>>, mut node: NonNull<Node<K, V>>) {
     to_attach.as_mut().links.value = ValueLinks {
         prev: node.as_ref().links.value.prev,
@@ -2009,13 +2019,13 @@ unsafe fn attach_before<K, V>(mut to_attach: NonNull<Node<K, V>>, mut node: NonN
         .next = to_attach;
 }
 
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn detach_node<K, V>(mut node: NonNull<Node<K, V>>) {
     node.as_mut().links.value.prev.as_mut().links.value.next = node.as_ref().links.value.next;
     node.as_mut().links.value.next.as_mut().links.value.prev = node.as_ref().links.value.prev;
 }
 
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn push_free<K, V>(
     free_list: &mut Option<NonNull<Node<K, V>>>,
     mut node: NonNull<Node<K, V>>,
@@ -2024,7 +2034,7 @@ unsafe fn push_free<K, V>(
     *free_list = Some(node);
 }
 
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn pop_free<K, V>(
     free_list: &mut Option<NonNull<Node<K, V>>>,
 ) -> Option<NonNull<Node<K, V>>> {
@@ -2036,7 +2046,7 @@ unsafe fn pop_free<K, V>(
     }
 }
 
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn allocate_node<K, V>(free_list: &mut Option<NonNull<Node<K, V>>>) -> NonNull<Node<K, V>> {
     if let Some(mut free) = pop_free(free_list) {
         free.as_mut().links.value = ValueLinks {
@@ -2058,7 +2068,7 @@ unsafe fn allocate_node<K, V>(free_list: &mut Option<NonNull<Node<K, V>>>) -> No
 }
 
 // Given node is assumed to be the guard node and is *not* dropped.
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn drop_value_nodes<K, V>(guard: NonNull<Node<K, V>>) {
     let mut cur = guard.as_ref().links.value.prev;
     while cur != guard {
@@ -2071,7 +2081,7 @@ unsafe fn drop_value_nodes<K, V>(guard: NonNull<Node<K, V>>) {
 
 // Drops all linked free nodes starting with the given node.  Free nodes are only non-circular
 // singly linked, and should have uninitialized keys / values.
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn drop_free_nodes<K, V>(mut free: Option<NonNull<Node<K, V>>>) {
     while let Some(some_free) = free {
         let next_free = some_free.as_ref().links.free.next;
@@ -2080,7 +2090,7 @@ unsafe fn drop_free_nodes<K, V>(mut free: Option<NonNull<Node<K, V>>>) {
     }
 }
 
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 unsafe fn remove_node<K, V>(
     free_list: &mut Option<NonNull<Node<K, V>>>,
     mut node: NonNull<Node<K, V>>,
@@ -2090,7 +2100,7 @@ unsafe fn remove_node<K, V>(
     node.as_mut().take_entry()
 }
 
-#[inline]
+#[cfg_attr(feature = "inline-more", inline)]
 fn hash_key<S, Q>(s: &S, k: &Q) -> u64
 where
     S: BuildHasher,

--- a/src/set.rs
+++ b/src/set.rs
@@ -1,4 +1,7 @@
-use std::{
+use crate::DefaultHashBuilder;
+use crate::TryReserveError;
+
+use core::{
     borrow::Borrow,
     fmt,
     hash::{BuildHasher, Hash, Hasher},
@@ -6,23 +9,22 @@ use std::{
     ops::{BitAnd, BitOr, BitXor, Sub},
 };
 
-use hashbrown::hash_map::DefaultHashBuilder;
-
-use crate::linked_hash_map::{self, LinkedHashMap, TryReserveError};
+use crate::linked_hash_map::{self, LinkedHashMap};
 
 pub struct LinkedHashSet<T, S = DefaultHashBuilder> {
     map: LinkedHashMap<T, (), S>,
 }
 
+#[cfg(feature = "ahash")]
 impl<T: Hash + Eq> LinkedHashSet<T, DefaultHashBuilder> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn new() -> LinkedHashSet<T, DefaultHashBuilder> {
         LinkedHashSet {
             map: LinkedHashMap::new(),
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_capacity(capacity: usize) -> LinkedHashSet<T, DefaultHashBuilder> {
         LinkedHashSet {
             map: LinkedHashMap::with_capacity(capacity),
@@ -31,41 +33,41 @@ impl<T: Hash + Eq> LinkedHashSet<T, DefaultHashBuilder> {
 }
 
 impl<T, S> LinkedHashSet<T, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn capacity(&self) -> usize {
         self.map.capacity()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             iter: self.map.keys(),
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn len(&self) -> usize {
         self.map.len()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn drain(&mut self) -> Drain<T> {
         Drain {
             iter: self.map.drain(),
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn clear(&mut self) {
         self.map.clear()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> bool,
@@ -79,41 +81,41 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_hasher(hasher: S) -> LinkedHashSet<T, S> {
         LinkedHashSet {
             map: LinkedHashMap::with_hasher(hasher),
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> LinkedHashSet<T, S> {
         LinkedHashSet {
             map: LinkedHashMap::with_capacity_and_hasher(capacity, hasher),
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn hasher(&self) -> &S {
         self.map.hasher()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn reserve(&mut self, additional: usize) {
         self.map.reserve(additional)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.map.try_reserve(additional)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn shrink_to_fit(&mut self) {
         self.map.shrink_to_fit()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn difference<'a>(&'a self, other: &'a LinkedHashSet<T, S>) -> Difference<'a, T, S> {
         Difference {
             iter: self.iter(),
@@ -121,7 +123,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn symmetric_difference<'a>(
         &'a self,
         other: &'a LinkedHashSet<T, S>,
@@ -131,7 +133,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn intersection<'a>(&'a self, other: &'a LinkedHashSet<T, S>) -> Intersection<'a, T, S> {
         Intersection {
             iter: self.iter(),
@@ -139,14 +141,14 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn union<'a>(&'a self, other: &'a LinkedHashSet<T, S>) -> Union<'a, T, S> {
         Union {
             iter: self.iter().chain(other.difference(self)),
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -155,7 +157,7 @@ where
         self.map.contains_key(value)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
     where
         T: Borrow<Q>,
@@ -164,7 +166,7 @@ where
         self.map.raw_entry().from_key(value).map(|p| p.0)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_or_insert(&mut self, value: T) -> &T {
         self.map
             .raw_entry_mut()
@@ -173,7 +175,7 @@ where
             .0
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn get_or_insert_with<Q: ?Sized, F>(&mut self, value: &Q, f: F) -> &T
     where
         T: Borrow<Q>,
@@ -187,17 +189,17 @@ where
             .0
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn is_disjoint(&self, other: &LinkedHashSet<T, S>) -> bool {
         self.iter().all(|v| !other.contains(v))
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn is_subset(&self, other: &LinkedHashSet<T, S>) -> bool {
         self.iter().all(|v| other.contains(v))
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn is_superset(&self, other: &LinkedHashSet<T, S>) -> bool {
         other.is_subset(self)
     }
@@ -207,7 +209,7 @@ where
     /// If the set did not have this value present, inserts it at the *back* of the internal linked
     /// list and returns true, otherwise it moves the existing value to the *back* of the internal
     /// linked list and returns false.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn insert(&mut self, value: T) -> bool {
         self.map.insert(value, ()).is_none()
     }
@@ -216,7 +218,7 @@ where
     ///
     /// If a previous value existed, returns the replaced value.  In this case, the value's position
     /// in the internal linked list is *not* changed.
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn replace(&mut self, value: T) -> Option<T> {
         match self.map.entry(value) {
             linked_hash_map::Entry::Occupied(occupied) => Some(occupied.replace_key()),
@@ -227,7 +229,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -236,7 +238,7 @@ where
         self.map.remove(value).is_some()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
     where
         T: Borrow<Q>,
@@ -248,27 +250,28 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn front(&self) -> Option<&T> {
         self.map.front().map(|(k, _)| k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn pop_front(&mut self) -> Option<T> {
         self.map.pop_front().map(|(k, _)| k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn back(&self) -> Option<&T> {
         self.map.back().map(|(k, _)| k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     pub fn pop_back(&mut self) -> Option<T> {
         self.map.pop_back().map(|(k, _)| k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_front<Q: ?Sized>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -283,7 +286,8 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_back<Q: ?Sized>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -300,7 +304,7 @@ where
 }
 
 impl<T: Hash + Eq + Clone, S: BuildHasher + Clone> Clone for LinkedHashSet<T, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Self {
         let map = self.map.clone();
         Self { map }
@@ -312,7 +316,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().eq(other)
     }
@@ -323,7 +327,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn hash<H: Hasher>(&self, state: &mut H) {
         for e in self {
             e.hash(state);
@@ -342,7 +346,7 @@ impl<T, S> fmt::Debug for LinkedHashSet<T, S>
 where
     T: fmt::Debug,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
     }
@@ -353,7 +357,7 @@ where
     T: Eq + Hash,
     S: BuildHasher + Default,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> LinkedHashSet<T, S> {
         let mut set = LinkedHashSet::with_hasher(Default::default());
         set.extend(iter);
@@ -366,7 +370,7 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.map.extend(iter.into_iter().map(|k| (k, ())));
     }
@@ -377,7 +381,7 @@ where
     T: 'a + Eq + Hash + Copy,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         self.extend(iter.into_iter().cloned());
     }
@@ -387,7 +391,7 @@ impl<T, S> Default for LinkedHashSet<T, S>
 where
     S: Default,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn default() -> LinkedHashSet<T, S> {
         LinkedHashSet {
             map: LinkedHashMap::default(),
@@ -402,7 +406,7 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn bitor(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.union(rhs).cloned().collect()
     }
@@ -415,7 +419,7 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn bitand(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.intersection(rhs).cloned().collect()
     }
@@ -428,7 +432,7 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn bitxor(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.symmetric_difference(rhs).cloned().collect()
     }
@@ -441,7 +445,7 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn sub(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.difference(rhs).cloned().collect()
     }
@@ -481,7 +485,7 @@ impl<'a, T, S> IntoIterator for &'a LinkedHashSet<T, S> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
     }
@@ -491,7 +495,7 @@ impl<T, S> IntoIterator for LinkedHashSet<T, S> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn into_iter(self) -> IntoIter<T> {
         IntoIter {
             iter: self.map.into_iter(),
@@ -500,7 +504,7 @@ impl<T, S> IntoIterator for LinkedHashSet<T, S> {
 }
 
 impl<'a, K> Clone for Iter<'a, K> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Iter<'a, K> {
         Iter {
             iter: self.iter.clone(),
@@ -510,12 +514,12 @@ impl<'a, K> Clone for Iter<'a, K> {
 impl<'a, K> Iterator for Iter<'a, K> {
     type Item = &'a K;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a K> {
         self.iter.next()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
@@ -524,14 +528,14 @@ impl<'a, K> Iterator for Iter<'a, K> {
 impl<'a, K> ExactSizeIterator for Iter<'a, K> {}
 
 impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<&'a T> {
         self.iter.next_back()
     }
 }
 
 impl<'a, K: fmt::Debug> fmt::Debug for Iter<'a, K> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -540,12 +544,12 @@ impl<'a, K: fmt::Debug> fmt::Debug for Iter<'a, K> {
 impl<K> Iterator for IntoIter<K> {
     type Item = K;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<K> {
         self.iter.next().map(|(k, _)| k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
@@ -554,7 +558,7 @@ impl<K> Iterator for IntoIter<K> {
 impl<K> ExactSizeIterator for IntoIter<K> {}
 
 impl<K> DoubleEndedIterator for IntoIter<K> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<K> {
         self.iter.next_back().map(|(k, _)| k)
     }
@@ -563,19 +567,19 @@ impl<K> DoubleEndedIterator for IntoIter<K> {
 impl<'a, K> Iterator for Drain<'a, K> {
     type Item = K;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<K> {
         self.iter.next().map(|(k, _)| k)
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
 }
 
 impl<'a, K> DoubleEndedIterator for Drain<'a, K> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next_back(&mut self) -> Option<K> {
         self.iter.next_back().map(|(k, _)| k)
     }
@@ -584,7 +588,7 @@ impl<'a, K> DoubleEndedIterator for Drain<'a, K> {
 impl<'a, K> ExactSizeIterator for Drain<'a, K> {}
 
 impl<'a, T, S> Clone for Intersection<'a, T, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Intersection<'a, T, S> {
         Intersection {
             iter: self.iter.clone(),
@@ -600,7 +604,7 @@ where
 {
     type Item = &'a T;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a T> {
         loop {
             match self.iter.next() {
@@ -614,7 +618,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (_, upper) = self.iter.size_hint();
         (0, upper)
@@ -626,14 +630,14 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, T, S> Clone for Difference<'a, T, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Difference<'a, T, S> {
         Difference {
             iter: self.iter.clone(),
@@ -649,7 +653,7 @@ where
 {
     type Item = &'a T;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a T> {
         loop {
             match self.iter.next() {
@@ -663,7 +667,7 @@ where
         }
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (_, upper) = self.iter.size_hint();
         (0, upper)
@@ -675,14 +679,14 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, T, S> Clone for SymmetricDifference<'a, T, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> SymmetricDifference<'a, T, S> {
         SymmetricDifference {
             iter: self.iter.clone(),
@@ -697,12 +701,12 @@ where
 {
     type Item = &'a T;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a T> {
         self.iter.next()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }
@@ -713,14 +717,14 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, T, S> Clone for Union<'a, T, S> {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn clone(&self) -> Union<'a, T, S> {
         Union {
             iter: self.iter.clone(),
@@ -733,7 +737,7 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -746,12 +750,12 @@ where
 {
     type Item = &'a T;
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn next(&mut self) -> Option<&'a T> {
         self.iter.next()
     }
 
-    #[inline]
+    #[cfg_attr(feature = "inline-more", inline)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.iter.size_hint()
     }

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "serde_impl")]
+#![cfg(feature = "serde")]
 
 use fxhash::FxBuildHasher;
 use hashlink::{LinkedHashMap, LinkedHashSet};


### PR DESCRIPTION
Hi @kyren , I want to merge all src changes in [ritelinked](https://github.com/ritelabs/ritelinked) to hashlink , and continue to maintain hashlink with you.

```
 7 files changed, 545 insertions(+), 468 deletions(-)
 rewrite src/lib.rs (84%)
 rename src/{linked_hash_map.rs => map.rs} (84%)
 rewrite src/serde.rs (93%)
 rename src/{linked_hash_set.rs => set.rs} (79%)
```

The main changes include the following aspects:

1. New features
    - `amortized`, powered by griddle, reduce the impact of the tail delay, which can help the hash link to remain stable when a large amount of data flows in, and the performance will not be affected too much. (I personally need this feature )
    - `inline-more`, If you turn off this feature: only keep `#[inline]` on the critical path , just like other crates. (We all know that inline is not a panacea.)
    - `#![no_std]`, yes, we now support using it under no std environment. 
2. Reorganize the code 
   - Reorganized the code with reference to projects such as hashbrown. like `serde.rs` .
   - More reasonable layout. like `lib.rs` .

Signed-off-by: Chojan Shang <psiace@outlook.com>