### PR TITLE
Add no_std Support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+extern crate alloc;
+
 pub mod linked_hash_map;
 pub mod linked_hash_set;
 pub mod lru_cache;

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     alloc::Layout,
     borrow::Borrow,
     cmp::Ordering,
@@ -11,6 +11,7 @@ use std::{
     ptr::{self, NonNull},
 };
 
+use alloc::boxed::Box;
 use hashbrown::{hash_map, HashMap};
 
 pub enum TryReserveError {

--- a/src/linked_hash_set.rs
+++ b/src/linked_hash_set.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     borrow::Borrow,
     fmt,
     hash::{BuildHasher, Hash, Hasher},

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     borrow::Borrow,
     fmt,
     hash::{BuildHasher, Hash},

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     fmt::{self, Formatter},
     hash::{BuildHasher, Hash},
     marker::PhantomData,


### PR DESCRIPTION
`hashbrown` is compatible with the "no_std" environment, so this library can certainly be made compatible with "no_std".
This commit adds `no_std` support for `hashlink` when disabling the feature `serde_impl`.

Pass test on `esp32-s3` with no_std environment.