### PR TITLE
LRU Callback Support and Serde support for LruCache

### DIFF
--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -262,6 +262,14 @@ where
     pub fn remove_lru(&mut self) -> Option<(K, V)> {
         self.map.pop_front()
     }
+
+    /// Peek at the least recently used entry and return a reference to it.
+    ///
+    /// If the `LruCache` is empty this will return None.
+    #[inline]
+    pub fn peek_lru(&mut self) -> Option<(&K, &V)> {
+        self.map.front()
+    }
 }
 
 impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Default + Clone> Clone for LruCache<K, V, S> {

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "serde_impl")]
 
-use fxhash::FxBuildHasher;
 use hashlink::{LinkedHashMap, LinkedHashSet, LruCache};
 use rustc_hash::FxHasher;
 use serde_test::{assert_tokens, Token};
@@ -175,7 +174,10 @@ fn lru_serde_tokens() {
 
 #[test]
 fn lru_serde_tokens_empty_generic() {
-    let map = LruCache::<char, u32, FxBuildHasher>::with_hasher(16, FxBuildHasher::default());
+    let map = LruCache::<char, u32, BuildHasherDefault<FxHasher>>::with_hasher(
+        16,
+        BuildHasherDefault::<FxHasher>::default(),
+    );
 
     assert_tokens(
         &map,
@@ -196,7 +198,7 @@ fn lru_serde_tokens_empty_generic() {
 
 #[test]
 fn lru_serde_tokens_generic() {
-    let mut map = LruCache::with_hasher(16, FxBuildHasher::default());
+    let mut map = LruCache::with_hasher(16, BuildHasherDefault::<FxHasher>::default());
     map.insert('a', 10);
     map.insert('b', 20);
     map.insert('c', 30);

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,10 +1,23 @@
 #![cfg(feature = "serde_impl")]
 
-use std::hash::BuildHasherDefault;
-
-use hashlink::{LinkedHashMap, LinkedHashSet};
+use fxhash::FxBuildHasher;
+use hashlink::{LinkedHashMap, LinkedHashSet, LruCache};
 use rustc_hash::FxHasher;
 use serde_test::{assert_tokens, Token};
+use std::hash::BuildHasherDefault;
+
+#[cfg(target_pointer_width = "64")]
+fn token_usize(t: usize) -> Token {
+    Token::U64(t as u64)
+}
+#[cfg(target_pointer_width = "32")]
+fn token_usize(t: usize) -> Token {
+    Token::U32(t as u32)
+}
+#[cfg(target_pointer_width = "16")]
+fn token_usize(t: usize) -> Token {
+    Token::U16(t as u16)
+}
 
 #[test]
 fn map_serde_tokens_empty() {
@@ -105,6 +118,108 @@ fn set_serde_tokens_generic() {
             Token::Char('b'),
             Token::Char('c'),
             Token::SeqEnd,
+        ],
+    );
+}
+
+#[test]
+fn lru_serde_tokens_empty() {
+    let map = LruCache::<char, u32>::new(16);
+
+    assert_tokens(
+        &map,
+        &[
+            Token::Struct {
+                name: "LruCache",
+                len: 2,
+            },
+            Token::Str("map"),
+            Token::Map { len: Some(0) },
+            Token::MapEnd,
+            Token::Str("max_size"),
+            token_usize(16),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn lru_serde_tokens() {
+    let mut map = LruCache::new(16);
+    map.insert('a', 10);
+    map.insert('b', 20);
+    map.insert('c', 30);
+
+    assert_tokens(
+        &map,
+        &[
+            Token::Struct {
+                name: "LruCache",
+                len: 2,
+            },
+            Token::Str("map"),
+            Token::Map { len: Some(3) },
+            Token::Char('a'),
+            Token::I32(10),
+            Token::Char('b'),
+            Token::I32(20),
+            Token::Char('c'),
+            Token::I32(30),
+            Token::MapEnd,
+            Token::Str("max_size"),
+            token_usize(16),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn lru_serde_tokens_empty_generic() {
+    let map = LruCache::<char, u32, FxBuildHasher>::with_hasher(16, FxBuildHasher::default());
+
+    assert_tokens(
+        &map,
+        &[
+            Token::Struct {
+                name: "LruCache",
+                len: 2,
+            },
+            Token::Str("map"),
+            Token::Map { len: Some(0) },
+            Token::MapEnd,
+            Token::Str("max_size"),
+            token_usize(16),
+            Token::StructEnd,
+        ],
+    );
+}
+
+#[test]
+fn lru_serde_tokens_generic() {
+    let mut map = LruCache::with_hasher(16, FxBuildHasher::default());
+    map.insert('a', 10);
+    map.insert('b', 20);
+    map.insert('c', 30);
+
+    assert_tokens(
+        &map,
+        &[
+            Token::Struct {
+                name: "LruCache",
+                len: 2,
+            },
+            Token::Str("map"),
+            Token::Map { len: Some(3) },
+            Token::Char('a'),
+            Token::I32(10),
+            Token::Char('b'),
+            Token::I32(20),
+            Token::Char('c'),
+            Token::I32(30),
+            Token::MapEnd,
+            Token::Str("max_size"),
+            token_usize(16),
+            Token::StructEnd,
         ],
     );
 }


### PR DESCRIPTION
Callback support lets you know when an mutable operation on an LruCache causes items to be removed from the cache. Right now there's no way to know if you're losing objects out of the cache. Adds:

insert_with_callback
entry_with_callback
set_capacity_with_callback
peek_lru