### PR TITLE
Convert to `hashbrown::HashTable`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
-hashbrown = "0.14"
+hashbrown = "0.14.2"
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -542,6 +542,20 @@ fn test_replace() {
 }
 
 #[test]
+fn test_reserve() {
+    let mut map = LinkedHashMap::new();
+
+    map.insert(1, 1);
+    map.insert(2, 2);
+    map.insert(3, 3);
+    map.insert(4, 4);
+
+    assert!(map.capacity() - map.len() < 100);
+    map.reserve(100);
+    assert!(map.capacity() - map.len() >= 100);
+}
+
+#[test]
 fn test_shrink_to_fit_resize() {
     let mut map = LinkedHashMap::new();
     map.shrink_to_fit();


### PR DESCRIPTION
`HashTable` is basically a safer version of `hashbrown::RawTable`. It leaves all of the hashing to be done externally, which means we don't need a `NullHasher` anymore. Code like `LinkedHashMap::shrink_to_fit` gets a lot simpler when it can just provide a hashing callback.

There's one public API change here, that `LinkedHashMap::reserve` and `try_reserve` are now constrained such that `K` can be (re)hashed with `S`, which is needed when `hashbrown` tries to move them to a new allocation. However, I think it was a bug that this was not required before, because it was previously possible to trigger `NullHasher`'s assertion when resizing -- the new `test_reserve` demonstrates a case that failed. Also, `LinkedHashSet` already has these constraints on its reserve methods.