### PR TITLE
Move the hasher to the inner `HashMap`

### DIFF
--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -238,7 +238,7 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
 
     #[inline]
     pub fn hasher(&self) -> &S {
-        &self.map.hasher()
+        self.map.hasher()
     }
 
     #[inline]
@@ -1958,12 +1958,12 @@ impl<K, V> NodeKey<K, V> {
 
     #[inline]
     fn key_ref(&self) -> &K {
-        &self.entry_ref().0
+        self.entry_ref().0
     }
 
     #[inline]
     fn value_ref(&self) -> &V {
-        &self.entry_ref().1
+        self.entry_ref().1
     }
 }
 

--- a/src/linked_hash_set.rs
+++ b/src/linked_hash_set.rs
@@ -161,7 +161,7 @@ where
         T: Borrow<Q>,
         Q: Hash + Eq,
     {
-        self.map.raw_entry().from_key(value).map(|p| p.0)
+        self.map.get_key_value(value).map(|p| p.0)
     }
 
     #[inline]
@@ -242,10 +242,7 @@ where
         T: Borrow<Q>,
         Q: Hash + Eq,
     {
-        match self.map.raw_entry_mut().from_key(value) {
-            linked_hash_map::RawEntryMut::Occupied(occupied) => Some(occupied.remove_entry().0),
-            linked_hash_map::RawEntryMut::Vacant(_) => None,
-        }
+        self.map.remove_entry(value).map(|(k, _)| k)
     }
 
     #[inline]

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -542,6 +542,20 @@ fn test_replace() {
 }
 
 #[test]
+fn test_reserve() {
+    let mut map = LinkedHashMap::new();
+
+    map.insert(1, 1);
+    map.insert(2, 2);
+    map.insert(3, 3);
+    map.insert(4, 4);
+
+    assert!(map.capacity() - map.len() < 100);
+    map.reserve(100);
+    assert!(map.capacity() - map.len() >= 100);
+}
+
+#[test]
 fn test_shrink_to_fit_resize() {
     let mut map = LinkedHashMap::new();
     map.shrink_to_fit();


### PR DESCRIPTION
This is an alternate to #21 that gives `HashMap` control of most hashing, by introducing a private `NodeKey<K, V>` type around the node pointer that only looks at `K` for equality and hashing. A private `NodeQ` wrapper also works to enable the generic `K: Borrow<Q>` relationship while having `NodeKey` in the middle.

As with #21, `LinkedHashMap::reserve` and `try_reserve` are now constrained such that `K` can be (re)hashed with `S`, which is needed when hashbrown tries to move them to a new allocation. The new `test_reserve` demonstrates a case that would have previously failed.

In addition, `OccupiedEntry` and `RawOccupiedEntryMut` now carry the `S` parameter as well, since `hashbrown`'s entry type needs it now that it's not just `NullHasher` (which has been removed).