### PR TITLE
feat: add `OccupiedEntry::insert_before` method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.65.0
+      - image: cimg/rust:1.75.0
     steps:
       - checkout
       - run:

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1238,7 +1238,7 @@ impl<'a, K, V, S> RawOccupiedEntryMut<'a, K, V, S> {
                         .insert_unique(hash, new_node, move |k| {
                             hash_key(hash_builder, (*k).as_ref().key_ref())
                         })
-                        .get();
+                        .into_mut();
                     attach_before(node, b_node);
                     None
                 }

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -575,3 +575,32 @@ fn test_shrink_to_fit_resize() {
         assert_eq!(map.get(&i).unwrap(), &i);
     }
 }
+
+#[test]
+fn test_insert_before() {
+    let mut map = LinkedHashMap::new();
+
+    map.insert(1, 1);
+    map.insert(2, 2);
+    map.insert(3, 3);
+    map.insert(4, 4);
+
+    // Insert-before a new key/value pair into the map, i.e. the key does not exist.
+    if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
+        let pv = entry.insert_before(5, 5);
+        assert!(pv.is_none());
+    }
+
+    // Insert-before an existing key with updated value, relocate the key in the underlying
+    // linked-list as requested.
+    if let linked_hash_map::Entry::Occupied(entry) = map.entry(1) {
+        let pv = entry.insert_before(2, 6);
+        assert!(pv.is_some());
+        assert_eq!(pv.unwrap(), 2);
+    }
+
+    assert!(map
+        .iter()
+        .map(|(k, v)| (*k, *v))
+        .eq([(2, 6), (1, 1), (5, 5), (3, 3), (4, 4)].iter().copied()));
+}


### PR DESCRIPTION
## Motivation

Add a method that enables us to insert elements in the middle of the underlying linked-list. Initial discussion is in https://github.com/kyren/hashlink/issues/23.

## In this PR

Following our discussion, I've implemented the `OccupiedEntry::insert_before` method. It may seem ad hoc, but it's functioning as expected. 

I'm open to further discussions about a more general API. This PR is primarily for tracking progress, not necessarily for immediate merging.