### PR TITLE
feat: add `CursorMut`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.65.0
+      - image: cimg/rust:1.75.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/rust:1.75.0
+      - image: cimg/rust:1.65.0
     steps:
       - checkout
       - run:

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1793,7 +1793,7 @@ impl<'a, K, V, S> CursorMut<'a, K, V, S> {
                 }
             }
         } else {
-            unreachable!("underlying doubly-linked list is not initialized")
+            None
         }
     }
 

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -504,19 +504,40 @@ where
         }
     }
 
-    /// Returns the `CursorMut` over the _guard_ node.
+    /// Returns the `CursorMut` over the front node.
     ///
-    /// Note: The `CursorMut` over the _guard_ node in an empty `LinkedHashMap` will always
-    ///       return `None` as its current eliment, regardless of any move in any direction.
-    pub fn cursor_mut(&mut self) -> CursorMut<K, V, S> {
+    /// Note: The `CursorMut` is pointing to the _guard_ node in an empty `LinkedHashMap` and
+    ///       will always return `None` as its current element, regardless of any move in any
+    ///       direction.
+    pub fn cursor_front_mut(&mut self) -> CursorMut<K, V, S> {
         unsafe { ensure_guard_node(&mut self.values) };
-        CursorMut {
+        let mut c = CursorMut {
             cur: self.values.as_ptr(),
             hash_builder: &self.hash_builder,
             free: &mut self.free,
             values: &mut self.values,
             table: &mut self.table,
-        }
+        };
+        c.move_next();
+        c
+    }
+
+    /// Returns the `CursorMut` over the back node.
+    ///
+    /// Note: The `CursorMut` is pointing to the _guard_ node in an empty `LinkedHashMap` and
+    ///       will always return `None` as its current element, regardless of any move in any
+    ///       direction.
+    pub fn cursor_back_mut(&mut self) -> CursorMut<K, V, S> {
+        unsafe { ensure_guard_node(&mut self.values) };
+        let mut c = CursorMut {
+            cur: self.values.as_ptr(),
+            hash_builder: &self.hash_builder,
+            free: &mut self.free,
+            values: &mut self.values,
+            table: &mut self.table,
+        };
+        c.move_prev();
+        c
     }
 }
 

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1898,11 +1898,11 @@ impl<'a, K, V, S> CursorMut<'a, K, V, S> {
                 Err(_) => {
                     let mut new_node = allocate_node(self.free);
                     new_node.as_mut().put_entry((key, value));
+                    attach_before(new_node, before());
                     let hash_builder = self.hash_builder;
                     self.table.insert_unique(hash, new_node, move |k| {
                         hash_key(hash_builder, (*k).as_ref().key_ref())
                     });
-                    attach_before(new_node, before());
                     None
                 }
             }

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1885,8 +1885,10 @@ impl<'a, K, V, S> CursorMut<'a, K, V, S> {
                 Ok(occupied) => {
                     let mut node = *occupied.into_mut();
                     let pv = mem::replace(&mut node.as_mut().entry_mut().1, value);
-                    detach_node(node);
-                    attach_before(node, before);
+                    if node != before {
+                        detach_node(node);
+                        attach_before(node, before);
+                    }
                     Some(pv)
                 }
                 Err(_) => {

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1423,11 +1423,6 @@ pub struct Drain<'a, K, V> {
 /// - The current implementation does not include an `index` method, as it does not track the index
 ///   of its elements. It operates by providing items as key-value tuples, allowing the value to be
 ///   modified via a mutable reference while the key could not be changed.
-/// - The current implementation does not include `splice_*`, `split_*`, `as_cursor`, or
-///   `remove_current` methods, as there hasn't been a strong demand for these features in
-///   real-world scenarios. However, they can be readily incorporated into the existing codebase if
-///   needed.
-/// - For added convenience, it includes the `move_at` method.
 ///
 pub struct CursorMut<'a, K, V, S> {
     cur: *mut Node<K, V>,

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1813,32 +1813,6 @@ impl<'a, K, V, S> CursorMut<'a, K, V, S> {
         self.muv(|| at);
     }
 
-    /// Positions the cursor at the element associated with the specified key. Returns `true`
-    /// if the element exists and the operation succeeds, or `false` if the element does not
-    /// exist.
-    #[inline]
-    pub fn move_at(&mut self, key: &K) -> bool
-    where
-        K: Eq + Hash,
-        S: BuildHasher,
-    {
-        unsafe {
-            let hash = hash_key(self.hash_builder, key);
-            let i_entry = self
-                .table
-                .find_entry(hash, |o| (*o).as_ref().key_ref().eq(key));
-
-            match i_entry {
-                Ok(occupied) => {
-                    let at = *occupied.get();
-                    self.muv(|| at);
-                    true
-                }
-                Err(_) => false,
-            }
-        }
-    }
-
     // Updates the pointer to the current element to the one returned by the at closure function.
     #[inline]
     fn muv(&mut self, at: impl FnOnce() -> NonNull<Node<K, V>>) {

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1817,16 +1817,16 @@ impl<'a, K, V, S> CursorMut<'a, K, V, S> {
     /// if the element exists and the operation succeeds, or `false` if the element does not
     /// exist.
     #[inline]
-    pub fn move_at(&mut self, key: K) -> bool
+    pub fn move_at(&mut self, key: &K) -> bool
     where
         K: Eq + Hash,
         S: BuildHasher,
     {
         unsafe {
-            let hash = hash_key(self.hash_builder, &key);
+            let hash = hash_key(self.hash_builder, key);
             let i_entry = self
                 .table
-                .find_entry(hash, |o| (*o).as_ref().key_ref().eq(&key));
+                .find_entry(hash, |o| (*o).as_ref().key_ref().eq(key));
 
             match i_entry {
                 Ok(occupied) => {

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -651,27 +651,6 @@ fn test_cursor_mut_move_prev() {
 }
 
 #[test]
-fn test_cursor_mut_move_at() {
-    let mut map = LinkedHashMap::new();
-
-    map.insert(3, 3);
-    map.insert(4, 4);
-    map.insert(5, 5);
-    map.insert(6, 6);
-
-    if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
-        let mut cursor = entry.cursor_mut();
-        let moved = cursor.move_at(&6);
-        assert!(moved);
-        let value = cursor.current();
-        assert!(value.is_some());
-        assert_eq!(value.unwrap().1, &mut 6);
-        let moved = cursor.move_at(&7);
-        assert!(!moved);
-    }
-}
-
-#[test]
 fn test_cursor_mut_pick_next() {
     let mut map = LinkedHashMap::new();
 

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -704,7 +704,7 @@ fn test_cursor_mut_insert_before() {
 
     // Insert new item in the middle
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(4) {
-        entry.cursor_mut().insert_before((5, 5));
+        entry.cursor_mut().insert_before(5, 5);
         assert!(map
             .iter()
             .map(|(k, v)| (*k, *v))
@@ -715,7 +715,7 @@ fn test_cursor_mut_insert_before() {
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
         let mut cursor = entry.cursor_mut();
         cursor.move_prev();
-        cursor.insert_before((6, 6));
+        cursor.insert_before(6, 6);
         assert!(map
             .iter()
             .map(|(k, v)| (*k, *v))
@@ -724,7 +724,7 @@ fn test_cursor_mut_insert_before() {
 
     // Relocate item and override value
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(5) {
-        entry.cursor_mut().insert_before((4, 42));
+        entry.cursor_mut().insert_before(4, 42);
         assert!(map
             .iter()
             .map(|(k, v)| (*k, *v))
@@ -741,7 +741,7 @@ fn test_cursor_mut_insert_after() {
 
     // Insert new item in the middle.
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
-        entry.cursor_mut().insert_after((5, 5));
+        entry.cursor_mut().insert_after(5, 5);
         assert!(map
             .iter()
             .map(|(k, v)| (*k, *v))
@@ -752,7 +752,7 @@ fn test_cursor_mut_insert_after() {
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(4) {
         let mut cursor = entry.cursor_mut();
         cursor.move_next();
-        cursor.insert_after((6, 6));
+        cursor.insert_after(6, 6);
         assert!(map
             .iter()
             .map(|(k, v)| (*k, *v))
@@ -769,7 +769,7 @@ fn test_cursor_front_mut() {
     assert!(cursor.current().is_none());
     cursor.move_next();
     assert!(cursor.current().is_none());
-    cursor.insert_after((1, 1));
+    cursor.insert_after(1, 1);
     cursor.move_next();
     assert!(cursor.current().is_some());
     assert_eq!(cursor.current().unwrap().1, &mut 1);

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -772,8 +772,6 @@ fn test_cursor_mut_insert_before_itself() {
     // handled explicitly.
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
         entry.cursor_mut().insert_before(3, 5);
-        let r = map.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>();
-        println!("{r:?}");
         assert!(map
             .iter()
             .map(|(k, v)| (*k, *v))

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -702,7 +702,7 @@ fn test_cursor_mut_insert_before() {
     map.insert(3, 3);
     map.insert(4, 4);
 
-    // Insert new item in the middle
+    // Insert new element in the middle
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(4) {
         entry.cursor_mut().insert_before(5, 5);
         assert!(map
@@ -711,7 +711,7 @@ fn test_cursor_mut_insert_before() {
             .eq([(3, 3), (5, 5), (4, 4)].iter().copied()));
     }
 
-    // Insert new item at the very end of the list
+    // Insert new element at the very end of the list
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
         let mut cursor = entry.cursor_mut();
         cursor.move_prev();
@@ -722,7 +722,7 @@ fn test_cursor_mut_insert_before() {
             .eq([(3, 3), (5, 5), (4, 4), (6, 6)].iter().copied()));
     }
 
-    // Relocate item and override value
+    // Relocate element and override value
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(5) {
         entry.cursor_mut().insert_before(4, 42);
         assert!(map
@@ -739,7 +739,7 @@ fn test_cursor_mut_insert_after() {
     map.insert(3, 3);
     map.insert(4, 4);
 
-    // Insert new item in the middle.
+    // Insert new element in the middle.
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
         entry.cursor_mut().insert_after(5, 5);
         assert!(map
@@ -748,7 +748,7 @@ fn test_cursor_mut_insert_after() {
             .eq([(3, 3), (5, 5), (4, 4)].iter().copied()));
     }
 
-    // Insert new item as the first one.
+    // Insert new element as the first one.
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(4) {
         let mut cursor = entry.cursor_mut();
         cursor.move_next();
@@ -763,7 +763,7 @@ fn test_cursor_mut_insert_after() {
 #[test]
 fn test_cursor_front_mut() {
     let mut map: LinkedHashMap<i32, i32> = LinkedHashMap::new();
-    // the CursorMut in an empty LinkedHashMap will always return `None` as its
+    // The `CursorMut`` in an empty LinkedHashMap will always return `None` as its
     // current element, regardless of any move in any direction.
     let mut cursor = map.cursor_front_mut();
     assert!(cursor.current().is_none());

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -761,6 +761,27 @@ fn test_cursor_mut_insert_after() {
 }
 
 #[test]
+fn test_cursor_mut_insert_before_itself() {
+    let mut map = LinkedHashMap::new();
+
+    map.insert(2, 2);
+    map.insert(3, 3);
+    map.insert(4, 4);
+
+    // Insert a new value before its key. This is a corner case that needs to be
+    // handled explicitly.
+    if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
+        entry.cursor_mut().insert_before(3, 5);
+        let r = map.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>();
+        println!("{r:?}");
+        assert!(map
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .eq([(2, 2), (3, 5), (4, 4)].iter().copied()));
+    }
+}
+
+#[test]
 fn test_cursor_front_mut() {
     let mut map: LinkedHashMap<i32, i32> = LinkedHashMap::new();
     // The `CursorMut`` in an empty LinkedHashMap will always return `None` as its

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -661,12 +661,12 @@ fn test_cursor_mut_move_at() {
 
     if let linked_hash_map::Entry::Occupied(entry) = map.entry(3) {
         let mut cursor = entry.cursor_mut();
-        let moved = cursor.move_at(6);
+        let moved = cursor.move_at(&6);
         assert!(moved);
         let value = cursor.current();
         assert!(value.is_some());
         assert_eq!(value.unwrap().1, &mut 6);
-        let moved = cursor.move_at(7);
+        let moved = cursor.move_at(&7);
         assert!(!moved);
     }
 }

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -780,3 +780,25 @@ fn test_cursor_mut_insert_after() {
             .eq([(6, 6), (3, 3), (5, 5), (4, 4)].iter().copied()));
     }
 }
+
+#[test]
+fn test_cursor_mut() {
+    let mut map: LinkedHashMap<i32, i32> = LinkedHashMap::new();
+    // CursorMut over the _guard_ node in an empty LinkedHashMap will always return `None` as its
+    // current eliment, regardless of any move in any direction.
+    let mut cursor = map.cursor_mut();
+    assert!(cursor.current().is_none());
+    cursor.move_next();
+    assert!(cursor.current().is_none());
+    cursor.insert_after((1, 1));
+    cursor.move_next();
+    assert!(cursor.current().is_some());
+    assert_eq!(cursor.current().unwrap().1, &mut 1);
+    cursor.move_next();
+    assert!(cursor.current().is_none());
+
+    assert!(map
+        .iter()
+        .map(|(k, v)| (*k, *v))
+        .eq([(1, 1)].iter().copied()));
+}

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -761,11 +761,11 @@ fn test_cursor_mut_insert_after() {
 }
 
 #[test]
-fn test_cursor_mut() {
+fn test_cursor_front_mut() {
     let mut map: LinkedHashMap<i32, i32> = LinkedHashMap::new();
-    // CursorMut over the _guard_ node in an empty LinkedHashMap will always return `None` as its
-    // current eliment, regardless of any move in any direction.
-    let mut cursor = map.cursor_mut();
+    // the CursorMut in an empty LinkedHashMap will always return `None` as its
+    // current element, regardless of any move in any direction.
+    let mut cursor = map.cursor_front_mut();
     assert!(cursor.current().is_none());
     cursor.move_next();
     assert!(cursor.current().is_none());
@@ -780,4 +780,24 @@ fn test_cursor_mut() {
         .iter()
         .map(|(k, v)| (*k, *v))
         .eq([(1, 1)].iter().copied()));
+
+    map.insert(2, 2);
+    map.insert(3, 3);
+
+    let mut cursor = map.cursor_front_mut();
+    assert!(cursor.current().is_some());
+    assert_eq!(cursor.current().unwrap().1, &mut 1);
+}
+
+#[test]
+fn test_cursor_back_mut() {
+    let mut map: LinkedHashMap<i32, i32> = LinkedHashMap::new();
+
+    map.insert(1, 1);
+    map.insert(2, 2);
+    map.insert(3, 3);
+
+    let mut cursor = map.cursor_back_mut();
+    assert!(cursor.current().is_some());
+    assert_eq!(cursor.current().unwrap().1, &mut 3);
 }


### PR DESCRIPTION
## Motivation

Add a feature that enables insert elements in the middle of the underlying linked-list. Initial discussion is in https://github.com/kyren/hashlink/issues/23.


Following further reflection since our initial discussion, I've implemented the `CursorMut` API as outlined in [my previous comment](https://github.com/kyren/hashlink/issues/23#issuecomment-1951460425). This pull request is intended to supersede #24, which I suggest we close in favor of this updated approach.

## In this PR

The difference to the _Cursor API_ from the [RFC](https://github.com/rust-lang/rfcs/blob/master/text/2570-linked-list-cursors.md):

- The methods `index`, `splice_*`, `split_*`, `as_cursor`, and `remove_current` have been omitted, as they are either not required for my purposes or are not applicable to the context of a `LinkedHashMap`, such as the `index` method.

I'm open to discussions about the API design and its implementation. I would appreciate your thoughts on the matter.

Kind regards,
Oleg