### PR TITLE
build: remove unnecessary `allocator-api2` dep.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
-hashbrown = "0.14.3"
+hashbrown = { version = "0.14.3", default-features = false, features = ["ahash", "inline-more"] }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Hey there @kyren! 👋🏻 [Positive heckler at 0:35 of your RustConf 2018 talk](https://www.youtube.com/watch?v=aKLntZcp27M&lc=UgwYMBxzfGMrc0eXL4x4AaABAg) here. 🙂 We meet again!

This time, I come representing some dependency management effort at Mozilla, where I've been auditing dependencies of crates like `libsqlite` 0.31, which includes `hashlink` 0.9.0. We've used previous versions of `hashlink` via this transitive dependency, but `hashlink`'s update to `hashbrown` 0.14 has an interesting wrinkle in it: it includes the `allocator-api2` feature/dependency combo by default. But…it doesn't seem like it's being meaningfully consumed by most crates using `hashbrown`. 😖

Turns out, this feature probably _doesn't_ make sense unless a consumer-of-a-consumer crate (i.e., something using `hashlink`) uses `allocator-api2` directly _and_ has access to the allocators that `hashlink`'s underlying `hashbrown` collections use (which isn't currently exposed). So, remove this with this PR. End-user applications can still re-enable this with a direct dependency on `hashbrown`, with which they can enable `allocator-api2` themselves.

I don't know why `hashbrown` made this a `default` feature, TBH. 🫤 It's been annoying (but doable) to combat this unnecessary dependency in other crates like `gpu-descriptor` (see <https://github.com/zakarumych/gpu-descriptor/pull/40>).