### PR TITLE
Upgrade to hashbrown 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"
-rustc-hash = "1.1"
+rustc-hash = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
+foldhash = { version = "0.1.3", default-features = false }
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/hashlink"
 readme = "README.md"
 keywords = ["data-structures", "no_std"]
 license = "MIT OR Apache-2.0"
+rust-version = "1.65"
 
 [badges]
 circle-ci = { repository = "kyren/hashlink", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
-hashbrown = { version = "0.14.3", default-features = false, features = ["ahash", "inline-more"] }
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["kyren <kerriganw@gmail.com>"]
 edition = "2018"
 description = "HashMap-like containers that hold their key-value pairs in a user controllable order"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,101 @@ pub mod lru_cache;
 #[cfg(feature = "serde_impl")]
 pub mod serde;
 
+use core::hash::{BuildHasher, Hasher};
+
 pub use linked_hash_map::LinkedHashMap;
 pub use linked_hash_set::LinkedHashSet;
 pub use lru_cache::LruCache;
+
+/// Default hash builder, matches hashbrown's default hasher.
+///
+/// See [`DefaultHasher`] for more details.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct DefaultHashBuilder(hashbrown::DefaultHashBuilder);
+
+impl BuildHasher for DefaultHashBuilder {
+    type Hasher = DefaultHasher;
+
+    #[inline]
+    fn build_hasher(&self) -> Self::Hasher {
+        DefaultHasher(self.0.build_hasher())
+    }
+}
+
+/// Default hasher, as selected by hashbrown.
+///
+/// Currently this is [`foldhash::fast::FoldHasher`].
+#[derive(Clone)]
+pub struct DefaultHasher(foldhash::fast::FoldHasher);
+
+impl Hasher for DefaultHasher {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes)
+    }
+
+    #[inline]
+    fn write_u8(&mut self, i: u8) {
+        self.0.write_u8(i)
+    }
+
+    #[inline]
+    fn write_u16(&mut self, i: u16) {
+        self.0.write_u16(i)
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.0.write_u32(i)
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0.write_u64(i)
+    }
+
+    #[inline]
+    fn write_u128(&mut self, i: u128) {
+        self.0.write_u128(i)
+    }
+
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        self.0.write_usize(i)
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0.finish()
+    }
+
+    #[inline]
+    fn write_i8(&mut self, i: i8) {
+        self.0.write_i8(i)
+    }
+
+    #[inline]
+    fn write_i16(&mut self, i: i16) {
+        self.0.write_i16(i)
+    }
+
+    #[inline]
+    fn write_i32(&mut self, i: i32) {
+        self.0.write_i32(i)
+    }
+
+    #[inline]
+    fn write_i64(&mut self, i: i64) {
+        self.0.write_i64(i)
+    }
+
+    #[inline]
+    fn write_i128(&mut self, i: i128) {
+        self.0.write_i128(i)
+    }
+
+    #[inline]
+    fn write_isize(&mut self, i: isize) {
+        self.0.write_isize(i)
+    }
+}

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -13,7 +13,8 @@ use core::{
 
 use alloc::boxed::Box;
 use hashbrown::hash_table::{self, HashTable};
-use hashbrown::DefaultHashBuilder;
+
+use crate::DefaultHashBuilder;
 
 pub enum TryReserveError {
     CapacityOverflow,

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -12,8 +12,8 @@ use core::{
 };
 
 use alloc::boxed::Box;
-use hashbrown::hash_map::DefaultHashBuilder;
 use hashbrown::hash_table::{self, HashTable};
+use hashbrown::DefaultHashBuilder;
 
 pub enum TryReserveError {
     CapacityOverflow,

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -972,7 +972,7 @@ where
     }
 }
 
-unsafe impl<'a, K, V, S> Send for RawEntryBuilder<'a, K, V, S>
+unsafe impl<K, V, S> Send for RawEntryBuilder<'_, K, V, S>
 where
     K: Send,
     V: Send,
@@ -980,7 +980,7 @@ where
 {
 }
 
-unsafe impl<'a, K, V, S> Sync for RawEntryBuilder<'a, K, V, S>
+unsafe impl<K, V, S> Sync for RawEntryBuilder<'_, K, V, S>
 where
     K: Sync,
     V: Sync,
@@ -1043,7 +1043,7 @@ where
     }
 }
 
-unsafe impl<'a, K, V, S> Send for RawEntryBuilderMut<'a, K, V, S>
+unsafe impl<K, V, S> Send for RawEntryBuilderMut<'_, K, V, S>
 where
     K: Send,
     V: Send,
@@ -1051,7 +1051,7 @@ where
 {
 }
 
-unsafe impl<'a, K, V, S> Sync for RawEntryBuilderMut<'a, K, V, S>
+unsafe impl<K, V, S> Sync for RawEntryBuilderMut<'_, K, V, S>
 where
     K: Sync,
     V: Sync,
@@ -1346,7 +1346,7 @@ impl<K, V, S> fmt::Debug for RawEntryBuilder<'_, K, V, S> {
     }
 }
 
-unsafe impl<'a, K, V, S> Send for RawOccupiedEntryMut<'a, K, V, S>
+unsafe impl<K, V, S> Send for RawOccupiedEntryMut<'_, K, V, S>
 where
     K: Send,
     V: Send,
@@ -1354,7 +1354,7 @@ where
 {
 }
 
-unsafe impl<'a, K, V, S> Sync for RawOccupiedEntryMut<'a, K, V, S>
+unsafe impl<K, V, S> Sync for RawOccupiedEntryMut<'_, K, V, S>
 where
     K: Sync,
     V: Sync,
@@ -1362,7 +1362,7 @@ where
 {
 }
 
-unsafe impl<'a, K, V, S> Send for RawVacantEntryMut<'a, K, V, S>
+unsafe impl<K, V, S> Send for RawVacantEntryMut<'_, K, V, S>
 where
     K: Send,
     V: Send,
@@ -1370,7 +1370,7 @@ where
 {
 }
 
-unsafe impl<'a, K, V, S> Sync for RawVacantEntryMut<'a, K, V, S>
+unsafe impl<K, V, S> Sync for RawVacantEntryMut<'_, K, V, S>
 where
     K: Sync,
     V: Sync,
@@ -1444,14 +1444,14 @@ impl<K, V> Drain<'_, K, V> {
     }
 }
 
-unsafe impl<'a, K, V> Send for Iter<'a, K, V>
+unsafe impl<K, V> Send for Iter<'_, K, V>
 where
     K: Send,
     V: Send,
 {
 }
 
-unsafe impl<'a, K, V> Send for IterMut<'a, K, V>
+unsafe impl<K, V> Send for IterMut<'_, K, V>
 where
     K: Send,
     V: Send,
@@ -1465,21 +1465,21 @@ where
 {
 }
 
-unsafe impl<'a, K, V> Send for Drain<'a, K, V>
+unsafe impl<K, V> Send for Drain<'_, K, V>
 where
     K: Send,
     V: Send,
 {
 }
 
-unsafe impl<'a, K, V> Sync for Iter<'a, K, V>
+unsafe impl<K, V> Sync for Iter<'_, K, V>
 where
     K: Sync,
     V: Sync,
 {
 }
 
-unsafe impl<'a, K, V> Sync for IterMut<'a, K, V>
+unsafe impl<K, V> Sync for IterMut<'_, K, V>
 where
     K: Sync,
     V: Sync,
@@ -1493,14 +1493,14 @@ where
 {
 }
 
-unsafe impl<'a, K, V> Sync for Drain<'a, K, V>
+unsafe impl<K, V> Sync for Drain<'_, K, V>
 where
     K: Sync,
     V: Sync,
 {
 }
 
-impl<'a, K, V> Clone for Iter<'a, K, V> {
+impl<K, V> Clone for Iter<'_, K, V> {
     #[inline]
     fn clone(&self) -> Self {
         Iter { ..*self }
@@ -1617,7 +1617,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
     }
 }
 
-impl<'a, K, V> Iterator for Drain<'a, K, V> {
+impl<K, V> Iterator for Drain<'_, K, V> {
     type Item = (K, V);
 
     #[inline]
@@ -1690,7 +1690,7 @@ impl<K, V> DoubleEndedIterator for IntoIter<K, V> {
     }
 }
 
-impl<'a, K, V> DoubleEndedIterator for Drain<'a, K, V> {
+impl<K, V> DoubleEndedIterator for Drain<'_, K, V> {
     #[inline]
     fn next_back(&mut self) -> Option<(K, V)> {
         if self.remaining == 0 {
@@ -1707,9 +1707,9 @@ impl<'a, K, V> DoubleEndedIterator for Drain<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {}
+impl<K, V> ExactSizeIterator for Iter<'_, K, V> {}
 
-impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {}
+impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {}
 
 impl<K, V> ExactSizeIterator for IntoIter<K, V> {}
 
@@ -1727,7 +1727,7 @@ impl<K, V> Drop for IntoIter<K, V> {
     }
 }
 
-impl<'a, K, V> Drop for Drain<'a, K, V> {
+impl<K, V> Drop for Drain<'_, K, V> {
     #[inline]
     fn drop(&mut self) {
         for _ in 0..self.remaining {
@@ -1762,7 +1762,7 @@ pub struct CursorMut<'a, K, V, S> {
     table: &'a mut hashbrown::HashTable<NonNull<Node<K, V>>>,
 }
 
-impl<'a, K, V, S> CursorMut<'a, K, V, S> {
+impl<K, V, S> CursorMut<'_, K, V, S> {
     /// Returns an `Option` of the current element in the list, provided it is not the
     /// _guard_ node, and `None` overwise.
     #[inline]
@@ -1944,7 +1944,7 @@ impl<'a, K, V> DoubleEndedIterator for Keys<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
+impl<K, V> ExactSizeIterator for Keys<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
@@ -1992,7 +1992,7 @@ impl<'a, K, V> DoubleEndedIterator for Values<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
+impl<K, V> ExactSizeIterator for Values<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
@@ -2035,7 +2035,7 @@ impl<'a, K, V> DoubleEndedIterator for ValuesMut<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for ValuesMut<'a, K, V> {
+impl<K, V> ExactSizeIterator for ValuesMut<'_, K, V> {
     #[inline]
     fn len(&self) -> usize {
         self.inner.len()
@@ -2163,6 +2163,7 @@ impl<K, V> Node<K, V> {
 }
 
 trait OptNonNullExt<T> {
+    #[allow(clippy::wrong_self_convention)]
     fn as_ptr(self) -> *mut T;
 }
 
@@ -2321,7 +2322,7 @@ struct DropFilteredValues<'a, K, V> {
     cur_free: Option<NonNull<Node<K, V>>>,
 }
 
-impl<'a, K, V> DropFilteredValues<'a, K, V> {
+impl<K, V> DropFilteredValues<'_, K, V> {
     #[inline]
     fn drop_later(&mut self, node: NonNull<Node<K, V>>) {
         unsafe {
@@ -2331,7 +2332,7 @@ impl<'a, K, V> DropFilteredValues<'a, K, V> {
     }
 }
 
-impl<'a, K, V> Drop for DropFilteredValues<'a, K, V> {
+impl<K, V> Drop for DropFilteredValues<'_, K, V> {
     fn drop(&mut self) {
         unsafe {
             let end_free = self.cur_free;

--- a/src/linked_hash_set.rs
+++ b/src/linked_hash_set.rs
@@ -6,7 +6,7 @@ use core::{
     ops::{BitAnd, BitOr, BitXor, Sub},
 };
 
-use hashbrown::hash_map::DefaultHashBuilder;
+use hashbrown::DefaultHashBuilder;
 
 use crate::linked_hash_map::{self, LinkedHashMap, TryReserveError};
 

--- a/src/linked_hash_set.rs
+++ b/src/linked_hash_set.rs
@@ -6,9 +6,8 @@ use core::{
     ops::{BitAnd, BitOr, BitXor, Sub},
 };
 
-use hashbrown::DefaultHashBuilder;
-
 use crate::linked_hash_map::{self, LinkedHashMap, TryReserveError};
+use crate::DefaultHashBuilder;
 
 pub struct LinkedHashSet<T, S = DefaultHashBuilder> {
     map: LinkedHashMap<T, (), S>,

--- a/src/linked_hash_set.rs
+++ b/src/linked_hash_set.rs
@@ -147,19 +147,19 @@ where
     }
 
     #[inline]
-    pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
+    pub fn contains<Q>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.map.contains_key(value)
     }
 
     #[inline]
-    pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
+    pub fn get<Q>(&self, value: &Q) -> Option<&T>
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.map.raw_entry().from_key(value).map(|p| p.0)
     }
@@ -174,10 +174,10 @@ where
     }
 
     #[inline]
-    pub fn get_or_insert_with<Q: ?Sized, F>(&mut self, value: &Q, f: F) -> &T
+    pub fn get_or_insert_with<Q, F>(&mut self, value: &Q, f: F) -> &T
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
         F: FnOnce(&Q) -> T,
     {
         self.map
@@ -228,19 +228,19 @@ where
     }
 
     #[inline]
-    pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+    pub fn remove<Q>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.map.remove(value).is_some()
     }
 
     #[inline]
-    pub fn take<Q: ?Sized>(&mut self, value: &Q) -> Option<T>
+    pub fn take<Q>(&mut self, value: &Q) -> Option<T>
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self.map.raw_entry_mut().from_key(value) {
             linked_hash_map::RawEntryMut::Occupied(occupied) => Some(occupied.remove_entry().0),
@@ -269,10 +269,10 @@ where
     }
 
     #[inline]
-    pub fn to_front<Q: ?Sized>(&mut self, value: &Q) -> bool
+    pub fn to_front<Q>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self.map.raw_entry_mut().from_key(value) {
             linked_hash_map::RawEntryMut::Occupied(mut occupied) => {
@@ -284,10 +284,10 @@ where
     }
 
     #[inline]
-    pub fn to_back<Q: ?Sized>(&mut self, value: &Q) -> bool
+    pub fn to_back<Q>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self.map.raw_entry_mut().from_key(value) {
             linked_hash_map::RawEntryMut::Occupied(mut occupied) => {
@@ -403,7 +403,7 @@ where
     }
 }
 
-impl<'a, 'b, T, S> BitOr<&'b LinkedHashSet<T, S>> for &'a LinkedHashSet<T, S>
+impl<T, S> BitOr<&LinkedHashSet<T, S>> for &LinkedHashSet<T, S>
 where
     T: Eq + Hash + Clone,
     S: BuildHasher + Default,
@@ -416,7 +416,7 @@ where
     }
 }
 
-impl<'a, 'b, T, S> BitAnd<&'b LinkedHashSet<T, S>> for &'a LinkedHashSet<T, S>
+impl<T, S> BitAnd<&LinkedHashSet<T, S>> for &LinkedHashSet<T, S>
 where
     T: Eq + Hash + Clone,
     S: BuildHasher + Default,
@@ -429,7 +429,7 @@ where
     }
 }
 
-impl<'a, 'b, T, S> BitXor<&'b LinkedHashSet<T, S>> for &'a LinkedHashSet<T, S>
+impl<T, S> BitXor<&LinkedHashSet<T, S>> for &LinkedHashSet<T, S>
 where
     T: Eq + Hash + Clone,
     S: BuildHasher + Default,
@@ -442,7 +442,7 @@ where
     }
 }
 
-impl<'a, 'b, T, S> Sub<&'b LinkedHashSet<T, S>> for &'a LinkedHashSet<T, S>
+impl<T, S> Sub<&LinkedHashSet<T, S>> for &LinkedHashSet<T, S>
 where
     T: Eq + Hash + Clone,
     S: BuildHasher + Default,
@@ -529,7 +529,7 @@ impl<'a, K> Iterator for Iter<'a, K> {
     }
 }
 
-impl<'a, K> ExactSizeIterator for Iter<'a, K> {}
+impl<K> ExactSizeIterator for Iter<'_, K> {}
 
 impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     #[inline]
@@ -538,7 +538,7 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     }
 }
 
-impl<'a, K: fmt::Debug> fmt::Debug for Iter<'a, K> {
+impl<K: fmt::Debug> fmt::Debug for Iter<'_, K> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
@@ -568,7 +568,7 @@ impl<K> DoubleEndedIterator for IntoIter<K> {
     }
 }
 
-impl<'a, K> Iterator for Drain<'a, K> {
+impl<K> Iterator for Drain<'_, K> {
     type Item = K;
 
     #[inline]
@@ -582,14 +582,14 @@ impl<'a, K> Iterator for Drain<'a, K> {
     }
 }
 
-impl<'a, K> DoubleEndedIterator for Drain<'a, K> {
+impl<K> DoubleEndedIterator for Drain<'_, K> {
     #[inline]
     fn next_back(&mut self) -> Option<K> {
         self.iter.next_back().map(|(k, _)| k)
     }
 }
 
-impl<'a, K> ExactSizeIterator for Drain<'a, K> {}
+impl<K> ExactSizeIterator for Drain<'_, K> {}
 
 impl<'a, T, S> Clone for Intersection<'a, T, S> {
     #[inline]
@@ -629,7 +629,7 @@ where
     }
 }
 
-impl<'a, T, S> fmt::Debug for Intersection<'a, T, S>
+impl<T, S> fmt::Debug for Intersection<'_, T, S>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
@@ -678,7 +678,7 @@ where
     }
 }
 
-impl<'a, T, S> fmt::Debug for Difference<'a, T, S>
+impl<T, S> fmt::Debug for Difference<'_, T, S>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
@@ -716,7 +716,7 @@ where
     }
 }
 
-impl<'a, T, S> fmt::Debug for SymmetricDifference<'a, T, S>
+impl<T, S> fmt::Debug for SymmetricDifference<'_, T, S>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
@@ -736,7 +736,7 @@ impl<'a, T, S> Clone for Union<'a, T, S> {
     }
 }
 
-impl<'a, T, S> fmt::Debug for Union<'a, T, S>
+impl<T, S> fmt::Debug for Union<'_, T, S>
 where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -2,7 +2,6 @@ use core::{
     borrow::Borrow,
     fmt,
     hash::{BuildHasher, Hash},
-    usize,
 };
 
 use hashbrown::hash_map;

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -4,9 +4,8 @@ use core::{
     hash::{BuildHasher, Hash},
 };
 
-use hashbrown::DefaultHashBuilder;
-
 use crate::linked_hash_map::{self, LinkedHashMap};
+use crate::DefaultHashBuilder;
 
 pub use crate::linked_hash_map::{
     Drain, Entry, IntoIter, Iter, IterMut, OccupiedEntry, RawEntryBuilder, RawEntryBuilderMut,

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -4,7 +4,7 @@ use core::{
     hash::{BuildHasher, Hash},
 };
 
-use hashbrown::hash_map;
+use hashbrown::DefaultHashBuilder;
 
 use crate::linked_hash_map::{self, LinkedHashMap};
 
@@ -13,7 +13,7 @@ pub use crate::linked_hash_map::{
     RawOccupiedEntryMut, RawVacantEntryMut, VacantEntry,
 };
 
-pub struct LruCache<K, V, S = hash_map::DefaultHashBuilder> {
+pub struct LruCache<K, V, S = DefaultHashBuilder> {
     map: LinkedHashMap<K, V, S>,
     max_size: usize,
 }

--- a/tests/linked_hash_map.rs
+++ b/tests/linked_hash_map.rs
@@ -354,7 +354,7 @@ fn test_consuming_iter_with_free_list() {
 fn test_into_iter_drop() {
     struct Counter<'a>(&'a mut usize);
 
-    impl<'a> Drop for Counter<'a> {
+    impl Drop for Counter<'_> {
         fn drop(&mut self) {
             *self.0 += 1;
         }
@@ -386,7 +386,7 @@ fn test_drain() {
 
     struct Counter(Rc<Cell<u32>>);
 
-    impl<'a> Drop for Counter {
+    impl Drop for Counter {
         fn drop(&mut self) {
             self.0.set(self.0.get() + 1);
         }
@@ -476,7 +476,7 @@ fn test_retain() {
 
     struct Counter(Rc<Cell<u32>>);
 
-    impl<'a> Drop for Counter {
+    impl Drop for Counter {
         fn drop(&mut self) {
             self.0.set(self.0.get() + 1);
         }

--- a/tests/linked_hash_set.rs
+++ b/tests/linked_hash_set.rs
@@ -344,9 +344,7 @@ fn test_drain() {
             assert_eq!(last_i, 49);
         }
 
-        for _ in &s {
-            panic!("s should be empty!");
-        }
+        assert_eq!((&s).into_iter().count(), 0);
 
         s.extend(1..100);
     }
@@ -493,7 +491,6 @@ fn double_ended_iter() {
     assert_eq!(iter.next_back(), None);
     assert_eq!(iter.next(), None);
     assert_eq!(iter.next_back(), None);
-    drop(iter);
 
     let mut iter = set.drain();
     assert_eq!(iter.next(), Some(1));

--- a/tests/linked_hash_set.rs
+++ b/tests/linked_hash_set.rs
@@ -1,4 +1,4 @@
-use hashbrown::hash_map::DefaultHashBuilder;
+use hashbrown::DefaultHashBuilder;
 use hashlink::linked_hash_set::{self, LinkedHashSet};
 
 #[allow(dead_code)]

--- a/tests/linked_hash_set.rs
+++ b/tests/linked_hash_set.rs
@@ -1,5 +1,5 @@
-use hashbrown::DefaultHashBuilder;
 use hashlink::linked_hash_set::{self, LinkedHashSet};
+use hashlink::DefaultHashBuilder;
 
 #[allow(dead_code)]
 fn assert_covariance() {

--- a/tests/lru_cache.rs
+++ b/tests/lru_cache.rs
@@ -23,7 +23,7 @@ fn test_put_update() {
 fn test_contains_key() {
     let mut cache = LruCache::new(1);
     cache.insert("1", 10);
-    assert_eq!(cache.contains_key("1"), true);
+    assert!(cache.contains_key("1"));
 }
 
 #[test]


### PR DESCRIPTION
[RUSTSEC-2024-0402](https://rustsec.org/advisories/RUSTSEC-2024-0402.html) briefly stated that it affected hashbrown 0.14, but that [was later corrected](https://github.com/rustsec/advisory-db/commit/1fce689aa0c8e7cb7aa6584786812e52b53e963a). Probably still good to upgrade!