### PR TITLE
Remove the `foldhash` direct dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.10.0]
+- API incompatible change: upgrade `hashbrown` to 0.15 (thank you @djc!).
+- API incompatible change: we now wrap `DefaultHashBuilder` and `DefaultHasher`
+  from `hashbrown` so that in the future upgrading `hashbrown` is not an API
+  incompatible change (thank you @djc!).
+
 ## [0.9.1]
 - Bugfix: `LruCache::contains_key` should take `&self` and not move the entry as
   though it is accessed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
-foldhash = { version = "0.1.3", default-features = false }
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,8 @@ impl BuildHasher for DefaultHashBuilder {
 }
 
 /// Default hasher, as selected by hashbrown.
-///
-/// Currently this is [`foldhash::fast::FoldHasher`].
 #[derive(Clone)]
-pub struct DefaultHasher(foldhash::fast::FoldHasher);
+pub struct DefaultHasher(<hashbrown::DefaultHashBuilder as BuildHasher>::Hasher);
 
 impl Hasher for DefaultHasher {
     #[inline]


### PR DESCRIPTION
Instead, just refer to whatever hashbrown is using directly.