### PR TITLE
Fix unsound Send impls.

### DIFF
--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -973,22 +973,6 @@ where
     }
 }
 
-unsafe impl<K, V, S> Send for RawEntryBuilder<'_, K, V, S>
-where
-    K: Send,
-    V: Send,
-    S: Send,
-{
-}
-
-unsafe impl<K, V, S> Sync for RawEntryBuilder<'_, K, V, S>
-where
-    K: Sync,
-    V: Sync,
-    S: Sync,
-{
-}
-
 pub struct RawEntryBuilderMut<'a, K, V, S> {
     map: &'a mut LinkedHashMap<K, V, S>,
 }
@@ -1042,22 +1026,6 @@ where
             }),
         }
     }
-}
-
-unsafe impl<K, V, S> Send for RawEntryBuilderMut<'_, K, V, S>
-where
-    K: Send,
-    V: Send,
-    S: Send,
-{
-}
-
-unsafe impl<K, V, S> Sync for RawEntryBuilderMut<'_, K, V, S>
-where
-    K: Sync,
-    V: Sync,
-    S: Sync,
-{
 }
 
 pub enum RawEntryMut<'a, K, V, S> {
@@ -1447,8 +1415,8 @@ impl<K, V> Drain<'_, K, V> {
 
 unsafe impl<K, V> Send for Iter<'_, K, V>
 where
-    K: Send,
-    V: Send,
+    K: Sync,
+    V: Sync,
 {
 }
 


### PR DESCRIPTION
[This](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=eb8b155af8edb2048911458588fa0f22) safe code using this library produces UB.

A couple types had incorrect `Send` impls, namely `linked_hash_map::Iter`.

I removed the `Send` and `Sync` from `RawEntryBuilder(Mut)` because they just contains refs to LinkedHashMap which is already `Send` and `Sync` (`RawEntryBuilder`'s `Send` impl was also incorrect).

This ends up being the same as the [auto trait impl](https://doc.rust-lang.org/stable/std/collections/hash_map/struct.Iter.html#impl-Send-for-Iter%3C'a,+K,+V%3E) on `std::collections::hash_map::Iter`