### PR TITLE
Remove hashbrown/inline-more feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
-hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
There is no justifiable reason to force this addition here I think? It's meant purely as something the binary crate can enable if wanted if it makes more sense for performance in in their case. `#[inline]` is *not* a universal win, very often it can worsen performance and severely balloon binary sizes for no reason.

This feature flag simply adds the `#[inline]` attribute to a lot more methods within hashbrown, which in this case has the primary effect of lowering the LLVM inline threshold for relatively cold codepaths. TBH there is not a *lot* of reason to do this, hashbrown is already quite aggressive with explicit inlining hints without this feature and it only really makes sense to look at on an application per application basis.

IME it does usually look very good on microbenchmarks and seems like "free performance", but that line of reasoning falls apart completely in any sort of real binary with more than a couple hundred lines of code being executed on repeat.
