### PR TITLE
Update edition to 2021 & specify optional dependency pathway unambiguously

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hashlink"
 version = "0.10.0"
 authors = ["kyren <kerriganw@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "HashMap-like containers that hold their key-value pairs in a user controllable order"
 repository = "https://github.com/kyren/hashlink"
 documentation = "https://docs.rs/hashlink"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.65"
 circle-ci = { repository = "kyren/hashlink", branch = "master" }
 
 [features]
-serde_impl = ["serde"]
+serde_impl = ["dep:serde"]
 
 [dependencies]
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -20,7 +20,6 @@ where
     V: Serialize,
     S: BuildHasher,
 {
-    #[inline]
     fn serialize<T: Serializer>(&self, serializer: T) -> Result<T::Ok, T::Error> {
         let mut map_serializer = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
@@ -39,7 +38,7 @@ where
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Debug)]
-        pub struct LinkedHashMapVisitor<K, V, S> {
+        struct LinkedHashMapVisitor<K, V, S> {
             marker: PhantomData<LinkedHashMap<K, V, S>>,
         }
 
@@ -95,7 +94,6 @@ where
     T: Serialize + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn serialize<U: Serializer>(&self, serializer: U) -> Result<U::Ok, U::Error> {
         let mut seq_serializer = serializer.serialize_seq(Some(self.len()))?;
         for v in self {
@@ -112,7 +110,7 @@ where
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         #[derive(Debug)]
-        pub struct LinkedHashSetVisitor<T, S> {
+        struct LinkedHashSetVisitor<T, S> {
             marker: PhantomData<LinkedHashSet<T, S>>,
         }
 


### PR DESCRIPTION
Couple of small "maintenance" things:
- Update edition to 2021, no issues observed
- Use the `dep:crate` syntax to specify the dependency on `serde` by the `serde_impl` feature
- Remove two cases of what seems like do-nothing `pub` visibilities
- As a little side-quest, removes `#[inline]` attributes on `serialize` and `visit_seq` in the ser/de implementations. These can already be inlined even without LTO cross-crate because they are generic. There is also little reason to explicitly hint these to encourage additional inlining without a reason grounded in data due to their nature.