### PR TITLE
Rework all inlining attribute labels with consistent decisions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ pub struct DefaultHashBuilder(hashbrown::DefaultHashBuilder);
 impl BuildHasher for DefaultHashBuilder {
     type Hasher = DefaultHasher;
 
-    #[inline]
+    #[inline(always)]
     fn build_hasher(&self) -> Self::Hasher {
         DefaultHasher(self.0.build_hasher())
     }
@@ -33,73 +33,73 @@ impl BuildHasher for DefaultHashBuilder {
 pub struct DefaultHasher(<hashbrown::DefaultHashBuilder as BuildHasher>::Hasher);
 
 impl Hasher for DefaultHasher {
-    #[inline]
+    #[inline(always)]
     fn write(&mut self, bytes: &[u8]) {
         self.0.write(bytes)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_u8(&mut self, i: u8) {
         self.0.write_u8(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_u16(&mut self, i: u16) {
         self.0.write_u16(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_u32(&mut self, i: u32) {
         self.0.write_u32(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_u64(&mut self, i: u64) {
         self.0.write_u64(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_u128(&mut self, i: u128) {
         self.0.write_u128(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_usize(&mut self, i: usize) {
         self.0.write_usize(i)
     }
 
-    #[inline]
-    fn finish(&self) -> u64 {
-        self.0.finish()
-    }
-
-    #[inline]
+    #[inline(always)]
     fn write_i8(&mut self, i: i8) {
         self.0.write_i8(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_i16(&mut self, i: i16) {
         self.0.write_i16(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_i32(&mut self, i: i32) {
         self.0.write_i32(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_i64(&mut self, i: i64) {
         self.0.write_i64(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_i128(&mut self, i: i128) {
         self.0.write_i128(i)
     }
 
-    #[inline]
+    #[inline(always)]
     fn write_isize(&mut self, i: isize) {
         self.0.write_isize(i)
+    }
+
+    #[inline(always)]
+    fn finish(&self) -> u64 {
+        self.0.finish()
     }
 }

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -2088,6 +2088,7 @@ impl<T> OptNonNullExt<T> for Option<NonNull<T>> {
 #[inline]
 unsafe fn ensure_guard_node<K, V>(head: &mut Option<NonNull<Node<K, V>>>) {
     #[cold]
+    #[inline(never)]
     unsafe fn initialize<K,V>(head: &mut Option<NonNull<Node<K, V>>>) {
         let mut p = NonNull::new_unchecked(Box::into_raw(Box::new(Node {
             entry: MaybeUninit::uninit(),
@@ -2170,6 +2171,7 @@ unsafe fn allocate_node<K, V>(free_list: &mut Option<NonNull<Node<K, V>>>) -> No
 }
 
 // Given node is assumed to be the guard node and is *not* dropped.
+#[inline(never)]
 unsafe fn drop_value_nodes<K, V>(guard: NonNull<Node<K, V>>) {
     let mut cur = guard.as_ref().links.value.prev;
     while cur != guard {
@@ -2182,6 +2184,7 @@ unsafe fn drop_value_nodes<K, V>(guard: NonNull<Node<K, V>>) {
 
 // Drops all linked free nodes starting with the given node.  Free nodes are only non-circular
 // singly linked, and should have uninitialized keys / values.
+#[inline(never)]
 unsafe fn drop_free_nodes<K, V>(mut free: Option<NonNull<Node<K, V>>>) {
     while let Some(some_free) = free {
         let next_free = some_free.as_ref().links.free.next;

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -51,7 +51,6 @@ pub struct LinkedHashMap<K, V, S = DefaultHashBuilder> {
 }
 
 impl<K, V> LinkedHashMap<K, V> {
-    #[inline]
     pub fn new() -> Self {
         Self {
             hash_builder: DefaultHashBuilder::default(),
@@ -61,7 +60,6 @@ impl<K, V> LinkedHashMap<K, V> {
         }
     }
 
-    #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             hash_builder: DefaultHashBuilder::default(),
@@ -73,7 +71,6 @@ impl<K, V> LinkedHashMap<K, V> {
 }
 
 impl<K, V, S> LinkedHashMap<K, V, S> {
-    #[inline]
     pub fn with_hasher(hash_builder: S) -> Self {
         Self {
             hash_builder,
@@ -83,7 +80,6 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
     pub fn with_capacity_and_hasher(capacity: usize, hash_builder: S) -> Self {
         Self {
             hash_builder,
@@ -100,10 +96,9 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
 
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.table.is_empty()
     }
 
-    #[inline]
     pub fn clear(&mut self) {
         self.table.clear();
         if let Some(mut values) = self.values {
@@ -117,7 +112,6 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
     pub fn iter(&self) -> Iter<K, V> {
         let (head, tail) = if let Some(values) = self.values {
             unsafe {
@@ -136,7 +130,6 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
         let (head, tail) = if let Some(values) = self.values {
             unsafe {
@@ -155,7 +148,6 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
     pub fn drain(&mut self) -> Drain<'_, K, V> {
         unsafe {
             let (head, tail) = if let Some(mut values) = self.values {
@@ -182,17 +174,14 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
     pub fn keys(&self) -> Keys<K, V> {
         Keys { inner: self.iter() }
     }
 
-    #[inline]
     pub fn values(&self) -> Values<K, V> {
         Values { inner: self.iter() }
     }
 
-    #[inline]
     pub fn values_mut(&mut self) -> ValuesMut<K, V> {
         ValuesMut {
             inner: self.iter_mut(),
@@ -223,7 +212,6 @@ impl<K, V, S> LinkedHashMap<K, V, S> {
         }
     }
 
-    #[inline]
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&K, &mut V) -> bool,
@@ -441,14 +429,12 @@ where
         }
     }
 
-    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         let hash_builder = &self.hash_builder;
         self.table
             .reserve(additional, move |&n| unsafe { hash_node(hash_builder, n) });
     }
 
-    #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         let hash_builder = &self.hash_builder;
         self.table
@@ -461,7 +447,6 @@ where
             })
     }
 
-    #[inline]
     pub fn shrink_to_fit(&mut self) {
         let hash_builder = &self.hash_builder;
         unsafe {
@@ -559,14 +544,12 @@ impl<K, V, S> Default for LinkedHashMap<K, V, S>
 where
     S: Default,
 {
-    #[inline]
     fn default() -> Self {
         Self::with_hasher(S::default())
     }
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher + Default> FromIterator<(K, V)> for LinkedHashMap<K, V, S> {
-    #[inline]
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut map = Self::with_capacity_and_hasher(iter.size_hint().0, S::default());
@@ -580,14 +563,12 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_map().entries(self).finish()
     }
 }
 
 impl<K: Hash + Eq, V: PartialEq, S: BuildHasher> PartialEq for LinkedHashMap<K, V, S> {
-    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().eq(other)
     }
@@ -598,41 +579,34 @@ impl<K: Hash + Eq, V: Eq, S: BuildHasher> Eq for LinkedHashMap<K, V, S> {}
 impl<K: Hash + Eq + PartialOrd, V: PartialOrd, S: BuildHasher> PartialOrd
     for LinkedHashMap<K, V, S>
 {
-    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.iter().partial_cmp(other)
     }
 
-    #[inline]
     fn lt(&self, other: &Self) -> bool {
         self.iter().lt(other)
     }
 
-    #[inline]
     fn le(&self, other: &Self) -> bool {
         self.iter().le(other)
     }
 
-    #[inline]
     fn ge(&self, other: &Self) -> bool {
         self.iter().ge(other)
     }
 
-    #[inline]
     fn gt(&self, other: &Self) -> bool {
         self.iter().gt(other)
     }
 }
 
 impl<K: Hash + Eq + Ord, V: Ord, S: BuildHasher> Ord for LinkedHashMap<K, V, S> {
-    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.iter().cmp(other)
     }
 }
 
 impl<K: Hash + Eq, V: Hash, S: BuildHasher> Hash for LinkedHashMap<K, V, S> {
-    #[inline]
     fn hash<H: Hasher>(&self, h: &mut H) {
         for e in self.iter() {
             e.hash(h);
@@ -641,7 +615,6 @@ impl<K: Hash + Eq, V: Hash, S: BuildHasher> Hash for LinkedHashMap<K, V, S> {
 }
 
 impl<K, V, S> Drop for LinkedHashMap<K, V, S> {
-    #[inline]
     fn drop(&mut self) {
         unsafe {
             if let Some(values) = self.values {
@@ -683,7 +656,6 @@ where
 }
 
 impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LinkedHashMap<K, V, S> {
-    #[inline]
     fn clone(&self) -> Self {
         let mut map = Self::with_hasher(self.hash_builder.clone());
         map.extend(self.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -692,7 +664,6 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LinkedHas
 }
 
 impl<K: Hash + Eq, V, S: BuildHasher> Extend<(K, V)> for LinkedHashMap<K, V, S> {
-    #[inline]
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         for (k, v) in iter {
             self.insert(k, v);
@@ -706,7 +677,6 @@ where
     V: 'a + Copy,
     S: BuildHasher,
 {
-    #[inline]
     fn extend<I: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: I) {
         for (&k, &v) in iter {
             self.insert(k, v);
@@ -720,7 +690,6 @@ pub enum Entry<'a, K, V, S> {
 }
 
 impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for Entry<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Entry::Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
@@ -796,7 +765,6 @@ pub struct OccupiedEntry<'a, K, V, S> {
 }
 
 impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for OccupiedEntry<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OccupiedEntry")
             .field("key", self.key())
@@ -899,7 +867,6 @@ pub struct VacantEntry<'a, K, V, S> {
 }
 
 impl<K: fmt::Debug, V, S> fmt::Debug for VacantEntry<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VacantEntry").field(self.key()).finish()
     }
@@ -1275,14 +1242,12 @@ impl<'a, K, V, S> RawVacantEntryMut<'a, K, V, S> {
 }
 
 impl<K, V, S> fmt::Debug for RawEntryBuilderMut<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }
 }
 
 impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for RawEntryMut<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             RawEntryMut::Vacant(ref v) => f.debug_tuple("RawEntry").field(v).finish(),
@@ -1292,7 +1257,6 @@ impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for RawEntryMut<'_, K, V, S> {
 }
 
 impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for RawOccupiedEntryMut<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawOccupiedEntryMut")
             .field("key", self.key())
@@ -1302,14 +1266,12 @@ impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for RawOccupiedEntryMut<'_, K, 
 }
 
 impl<K, V, S> fmt::Debug for RawVacantEntryMut<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawVacantEntryMut").finish()
     }
 }
 
 impl<K, V, S> fmt::Debug for RawEntryBuilder<'_, K, V, S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }
@@ -1378,7 +1340,6 @@ pub struct Drain<'a, K, V> {
 }
 
 impl<K, V> IterMut<'_, K, V> {
-    #[inline]
     pub(crate) fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             head: self.head.as_ptr(),
@@ -1390,7 +1351,6 @@ impl<K, V> IterMut<'_, K, V> {
 }
 
 impl<K, V> IntoIter<K, V> {
-    #[inline]
     pub(crate) fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             head: self.head.as_ptr(),
@@ -1402,7 +1362,6 @@ impl<K, V> IntoIter<K, V> {
 }
 
 impl<K, V> Drain<'_, K, V> {
-    #[inline]
     pub(crate) fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             head: self.head.as_ptr(),
@@ -1470,14 +1429,12 @@ where
 }
 
 impl<K, V> Clone for Iter<'_, K, V> {
-    #[inline]
     fn clone(&self) -> Self {
         Iter { ..*self }
     }
 }
 
 impl<K: fmt::Debug, V: fmt::Debug> fmt::Debug for Iter<'_, K, V> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -1488,7 +1445,6 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -1499,7 +1455,6 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -1510,7 +1465,6 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.iter()).finish()
     }
@@ -1683,7 +1637,6 @@ impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {}
 impl<K, V> ExactSizeIterator for IntoIter<K, V> {}
 
 impl<K, V> Drop for IntoIter<K, V> {
-    #[inline]
     fn drop(&mut self) {
         for _ in 0..self.remaining {
             unsafe {
@@ -1697,15 +1650,12 @@ impl<K, V> Drop for IntoIter<K, V> {
 }
 
 impl<K, V> Drop for Drain<'_, K, V> {
-    #[inline]
     fn drop(&mut self) {
-        for _ in 0..self.remaining {
-            unsafe {
-                let mut tail = NonNull::new_unchecked(self.tail.as_ptr());
-                self.tail = Some(tail.as_ref().links.value.prev);
-                tail.as_mut().take_entry();
-                push_free(&mut *self.free.as_ptr(), tail);
-            }
+        unsafe {
+            let mut tail = NonNull::new_unchecked(self.tail.as_ptr());
+            self.tail = Some(tail.as_ref().links.value.prev);
+            tail.as_mut().take_entry();
+            push_free(&mut *self.free.as_ptr(), tail);
         }
     }
 }
@@ -1877,14 +1827,12 @@ pub struct Keys<'a, K, V> {
 }
 
 impl<K: fmt::Debug, V> fmt::Debug for Keys<'_, K, V> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, K, V> Clone for Keys<'a, K, V> {
-    #[inline]
     fn clone(&self) -> Keys<'a, K, V> {
         Keys {
             inner: self.inner.clone(),
@@ -1925,7 +1873,6 @@ pub struct Values<'a, K, V> {
 }
 
 impl<K, V> Clone for Values<'_, K, V> {
-    #[inline]
     fn clone(&self) -> Self {
         Values {
             inner: self.inner.clone(),
@@ -1934,7 +1881,6 @@ impl<K, V> Clone for Values<'_, K, V> {
 }
 
 impl<K, V: fmt::Debug> fmt::Debug for Values<'_, K, V> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -1977,7 +1923,6 @@ where
     K: fmt::Debug,
     V: fmt::Debug,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.inner.iter()).finish()
     }
@@ -2015,7 +1960,6 @@ impl<'a, K, V, S> IntoIterator for &'a LinkedHashMap<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
-    #[inline]
     fn into_iter(self) -> Iter<'a, K, V> {
         self.iter()
     }
@@ -2025,7 +1969,6 @@ impl<'a, K, V, S> IntoIterator for &'a mut LinkedHashMap<K, V, S> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
-    #[inline]
     fn into_iter(self) -> IterMut<'a, K, V> {
         self.iter_mut()
     }
@@ -2035,7 +1978,6 @@ impl<K, V, S> IntoIterator for LinkedHashMap<K, V, S> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
-    #[inline]
     fn into_iter(mut self) -> IntoIter<K, V> {
         unsafe {
             let (head, tail) = if let Some(values) = self.values {
@@ -2073,7 +2015,6 @@ struct ValueLinks<K, V> {
 }
 
 impl<K, V> Clone for ValueLinks<K, V> {
-    #[inline]
     fn clone(&self) -> Self {
         *self
     }
@@ -2086,7 +2027,6 @@ struct FreeLink<K, V> {
 }
 
 impl<K, V> Clone for FreeLink<K, V> {
-    #[inline]
     fn clone(&self) -> Self {
         *self
     }
@@ -2292,7 +2232,6 @@ struct DropFilteredValues<'a, K, V> {
 }
 
 impl<K, V> DropFilteredValues<'_, K, V> {
-    #[inline]
     fn drop_later(&mut self, node: NonNull<Node<K, V>>) {
         unsafe {
             detach_node(node);

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -1651,11 +1651,13 @@ impl<K, V> Drop for IntoIter<K, V> {
 
 impl<K, V> Drop for Drain<'_, K, V> {
     fn drop(&mut self) {
-        unsafe {
-            let mut tail = NonNull::new_unchecked(self.tail.as_ptr());
-            self.tail = Some(tail.as_ref().links.value.prev);
-            tail.as_mut().take_entry();
-            push_free(&mut *self.free.as_ptr(), tail);
+        for _ in 0..self.remaining {
+            unsafe {
+                let mut tail = NonNull::new_unchecked(self.tail.as_ptr());
+                self.tail = Some(tail.as_ref().links.value.prev);
+                tail.as_mut().take_entry();
+                push_free(&mut *self.free.as_ptr(), tail);
+            }
         }
     }
 }

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -2209,6 +2209,7 @@ where
     hash_key(s, node.as_ref().key_ref())
 }
 
+#[inline]
 fn hash_key<S, Q>(s: &S, k: &Q) -> u64
 where
     S: BuildHasher,

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -923,7 +923,6 @@ where
         self.from_hash(hash, move |o| k.eq(o.borrow()))
     }
 
-    #[inline]
     pub fn from_hash(
         self,
         hash: u64,
@@ -968,7 +967,6 @@ where
         self.from_hash(hash, move |o| k.eq(o.borrow()))
     }
 
-    #[inline]
     pub fn from_hash(
         self,
         hash: u64,

--- a/src/linked_hash_map.rs
+++ b/src/linked_hash_map.rs
@@ -2089,7 +2089,7 @@ impl<T> OptNonNullExt<T> for Option<NonNull<T>> {
 unsafe fn ensure_guard_node<K, V>(head: &mut Option<NonNull<Node<K, V>>>) {
     #[cold]
     #[inline(never)]
-    unsafe fn initialize<K,V>(head: &mut Option<NonNull<Node<K, V>>>) {
+    unsafe fn initialize<K, V>(head: &mut Option<NonNull<Node<K, V>>>) {
         let mut p = NonNull::new_unchecked(Box::into_raw(Box::new(Node {
             entry: MaybeUninit::uninit(),
             links: Links {

--- a/src/linked_hash_set.rs
+++ b/src/linked_hash_set.rs
@@ -14,14 +14,12 @@ pub struct LinkedHashSet<T, S = DefaultHashBuilder> {
 }
 
 impl<T: Hash + Eq> LinkedHashSet<T, DefaultHashBuilder> {
-    #[inline]
     pub fn new() -> LinkedHashSet<T, DefaultHashBuilder> {
         LinkedHashSet {
             map: LinkedHashMap::new(),
         }
     }
 
-    #[inline]
     pub fn with_capacity(capacity: usize) -> LinkedHashSet<T, DefaultHashBuilder> {
         LinkedHashSet {
             map: LinkedHashMap::with_capacity(capacity),
@@ -35,7 +33,6 @@ impl<T, S> LinkedHashSet<T, S> {
         self.map.capacity()
     }
 
-    #[inline]
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             iter: self.map.keys(),
@@ -52,19 +49,16 @@ impl<T, S> LinkedHashSet<T, S> {
         self.map.is_empty()
     }
 
-    #[inline]
     pub fn drain(&mut self) -> Drain<T> {
         Drain {
             iter: self.map.drain(),
         }
     }
 
-    #[inline]
     pub fn clear(&mut self) {
         self.map.clear()
     }
 
-    #[inline]
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> bool,
@@ -78,14 +72,12 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     pub fn with_hasher(hasher: S) -> LinkedHashSet<T, S> {
         LinkedHashSet {
             map: LinkedHashMap::with_hasher(hasher),
         }
     }
 
-    #[inline]
     pub fn with_capacity_and_hasher(capacity: usize, hasher: S) -> LinkedHashSet<T, S> {
         LinkedHashSet {
             map: LinkedHashMap::with_capacity_and_hasher(capacity, hasher),
@@ -97,22 +89,18 @@ where
         self.map.hasher()
     }
 
-    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         self.map.reserve(additional)
     }
 
-    #[inline]
     pub fn try_reserve(&mut self, additional: usize) -> Result<(), TryReserveError> {
         self.map.try_reserve(additional)
     }
 
-    #[inline]
     pub fn shrink_to_fit(&mut self) {
         self.map.shrink_to_fit()
     }
 
-    #[inline]
     pub fn difference<'a>(&'a self, other: &'a LinkedHashSet<T, S>) -> Difference<'a, T, S> {
         Difference {
             iter: self.iter(),
@@ -120,7 +108,6 @@ where
         }
     }
 
-    #[inline]
     pub fn symmetric_difference<'a>(
         &'a self,
         other: &'a LinkedHashSet<T, S>,
@@ -130,7 +117,6 @@ where
         }
     }
 
-    #[inline]
     pub fn intersection<'a>(&'a self, other: &'a LinkedHashSet<T, S>) -> Intersection<'a, T, S> {
         Intersection {
             iter: self.iter(),
@@ -138,7 +124,6 @@ where
         }
     }
 
-    #[inline]
     pub fn union<'a>(&'a self, other: &'a LinkedHashSet<T, S>) -> Union<'a, T, S> {
         Union {
             iter: self.iter().chain(other.difference(self)),
@@ -186,17 +171,14 @@ where
             .0
     }
 
-    #[inline]
     pub fn is_disjoint(&self, other: &LinkedHashSet<T, S>) -> bool {
         self.iter().all(|v| !other.contains(v))
     }
 
-    #[inline]
     pub fn is_subset(&self, other: &LinkedHashSet<T, S>) -> bool {
         self.iter().all(|v| other.contains(v))
     }
 
-    #[inline]
     pub fn is_superset(&self, other: &LinkedHashSet<T, S>) -> bool {
         other.is_subset(self)
     }
@@ -297,7 +279,6 @@ where
         }
     }
 
-    #[inline]
     pub fn retain_with_order<F>(&mut self, mut f: F)
     where
         F: FnMut(&T) -> bool,
@@ -307,7 +288,6 @@ where
 }
 
 impl<T: Hash + Eq + Clone, S: BuildHasher + Clone> Clone for LinkedHashSet<T, S> {
-    #[inline]
     fn clone(&self) -> Self {
         let map = self.map.clone();
         Self { map }
@@ -319,7 +299,6 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().eq(other)
     }
@@ -330,7 +309,6 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         for e in self {
             e.hash(state);
@@ -349,7 +327,6 @@ impl<T, S> fmt::Debug for LinkedHashSet<T, S>
 where
     T: fmt::Debug,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_set().entries(self.iter()).finish()
     }
@@ -360,7 +337,6 @@ where
     T: Eq + Hash,
     S: BuildHasher + Default,
 {
-    #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> LinkedHashSet<T, S> {
         let mut set = LinkedHashSet::with_hasher(Default::default());
         set.extend(iter);
@@ -373,7 +349,6 @@ where
     T: Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.map.extend(iter.into_iter().map(|k| (k, ())));
     }
@@ -384,7 +359,6 @@ where
     T: 'a + Eq + Hash + Copy,
     S: BuildHasher,
 {
-    #[inline]
     fn extend<I: IntoIterator<Item = &'a T>>(&mut self, iter: I) {
         self.extend(iter.into_iter().cloned());
     }
@@ -394,7 +368,6 @@ impl<T, S> Default for LinkedHashSet<T, S>
 where
     S: Default,
 {
-    #[inline]
     fn default() -> LinkedHashSet<T, S> {
         LinkedHashSet {
             map: LinkedHashMap::default(),
@@ -409,7 +382,6 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
     fn bitor(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.union(rhs).cloned().collect()
     }
@@ -422,7 +394,6 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
     fn bitand(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.intersection(rhs).cloned().collect()
     }
@@ -435,7 +406,6 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
     fn bitxor(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.symmetric_difference(rhs).cloned().collect()
     }
@@ -448,7 +418,6 @@ where
 {
     type Output = LinkedHashSet<T, S>;
 
-    #[inline]
     fn sub(self, rhs: &LinkedHashSet<T, S>) -> LinkedHashSet<T, S> {
         self.difference(rhs).cloned().collect()
     }
@@ -488,7 +457,6 @@ impl<'a, T, S> IntoIterator for &'a LinkedHashSet<T, S> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
-    #[inline]
     fn into_iter(self) -> Iter<'a, T> {
         self.iter()
     }
@@ -498,7 +466,6 @@ impl<T, S> IntoIterator for LinkedHashSet<T, S> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
-    #[inline]
     fn into_iter(self) -> IntoIter<T> {
         IntoIter {
             iter: self.map.into_iter(),
@@ -507,7 +474,6 @@ impl<T, S> IntoIterator for LinkedHashSet<T, S> {
 }
 
 impl<'a, K> Clone for Iter<'a, K> {
-    #[inline]
     fn clone(&self) -> Iter<'a, K> {
         Iter {
             iter: self.iter.clone(),
@@ -538,7 +504,6 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
 }
 
 impl<K: fmt::Debug> fmt::Debug for Iter<'_, K> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
@@ -591,7 +556,6 @@ impl<K> DoubleEndedIterator for Drain<'_, K> {
 impl<K> ExactSizeIterator for Drain<'_, K> {}
 
 impl<'a, T, S> Clone for Intersection<'a, T, S> {
-    #[inline]
     fn clone(&self) -> Intersection<'a, T, S> {
         Intersection {
             iter: self.iter.clone(),
@@ -633,14 +597,12 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, T, S> Clone for Difference<'a, T, S> {
-    #[inline]
     fn clone(&self) -> Difference<'a, T, S> {
         Difference {
             iter: self.iter.clone(),
@@ -682,14 +644,12 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, T, S> Clone for SymmetricDifference<'a, T, S> {
-    #[inline]
     fn clone(&self) -> SymmetricDifference<'a, T, S> {
         SymmetricDifference {
             iter: self.iter.clone(),
@@ -720,14 +680,12 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }
 }
 
 impl<'a, T, S> Clone for Union<'a, T, S> {
-    #[inline]
     fn clone(&self) -> Union<'a, T, S> {
         Union {
             iter: self.iter.clone(),
@@ -740,7 +698,6 @@ where
     T: fmt::Debug + Eq + Hash,
     S: BuildHasher,
 {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_list().entries(self.clone()).finish()
     }

--- a/src/lru_cache.rs
+++ b/src/lru_cache.rs
@@ -18,7 +18,6 @@ pub struct LruCache<K, V, S = DefaultHashBuilder> {
 }
 
 impl<K: Eq + Hash, V> LruCache<K, V> {
-    #[inline]
     pub fn new(capacity: usize) -> Self {
         LruCache {
             map: LinkedHashMap::new(),
@@ -29,14 +28,12 @@ impl<K: Eq + Hash, V> LruCache<K, V> {
     /// Create a new unbounded `LruCache` that does not automatically evict entries.
     ///
     /// A simple convenience method that is equivalent to `LruCache::new(usize::MAX)`
-    #[inline]
     pub fn new_unbounded() -> Self {
         LruCache::new(usize::MAX)
     }
 }
 
 impl<K, V, S> LruCache<K, V, S> {
-    #[inline]
     pub fn with_hasher(capacity: usize, hash_builder: S) -> Self {
         LruCache {
             map: LinkedHashMap::with_hasher(hash_builder),
@@ -59,27 +56,22 @@ impl<K, V, S> LruCache<K, V, S> {
         self.map.is_empty()
     }
 
-    #[inline]
     pub fn clear(&mut self) {
         self.map.clear();
     }
 
-    #[inline]
     pub fn iter(&self) -> Iter<K, V> {
         self.map.iter()
     }
 
-    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
         self.map.iter_mut()
     }
 
-    #[inline]
     pub fn drain(&mut self) -> Drain<K, V> {
         self.map.drain()
     }
 
-    #[inline]
     pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&K, &mut V) -> bool,
@@ -221,7 +213,6 @@ where
     ///
     /// If there are more entries in the `LruCache` than the new capacity will allow, they are
     /// removed.
-    #[inline]
     pub fn set_capacity(&mut self, capacity: usize) {
         for _ in capacity..self.len() {
             self.remove_lru();
@@ -239,7 +230,6 @@ where
 }
 
 impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LruCache<K, V, S> {
-    #[inline]
     fn clone(&self) -> Self {
         LruCache {
             map: self.map.clone(),
@@ -249,7 +239,6 @@ impl<K: Hash + Eq + Clone, V: Clone, S: BuildHasher + Clone> Clone for LruCache<
 }
 
 impl<K: Eq + Hash, V, S: BuildHasher> Extend<(K, V)> for LruCache<K, V, S> {
-    #[inline]
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         for (k, v) in iter {
             self.insert(k, v);
@@ -261,7 +250,6 @@ impl<K, V, S> IntoIterator for LruCache<K, V, S> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
-    #[inline]
     fn into_iter(self) -> IntoIter<K, V> {
         self.map.into_iter()
     }
@@ -271,7 +259,6 @@ impl<'a, K, V, S> IntoIterator for &'a LruCache<K, V, S> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
-    #[inline]
     fn into_iter(self) -> Iter<'a, K, V> {
         self.iter()
     }
@@ -281,7 +268,6 @@ impl<'a, K, V, S> IntoIterator for &'a mut LruCache<K, V, S> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
-    #[inline]
     fn into_iter(self) -> IterMut<'a, K, V> {
         self.iter_mut()
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -20,7 +20,6 @@ where
     V: Serialize,
     S: BuildHasher,
 {
-    #[inline]
     fn serialize<T: Serializer>(&self, serializer: T) -> Result<T::Ok, T::Error> {
         let mut map_serializer = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
@@ -51,12 +50,6 @@ where
             }
         }
 
-        impl<K, V, S> Default for LinkedHashMapVisitor<K, V, S> {
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
         impl<'de, K, V, S> Visitor<'de> for LinkedHashMapVisitor<K, V, S>
         where
             K: Deserialize<'de> + Eq + Hash,
@@ -84,7 +77,7 @@ where
             }
         }
 
-        deserializer.deserialize_map(LinkedHashMapVisitor::default())
+        deserializer.deserialize_map(LinkedHashMapVisitor::new())
     }
 }
 
@@ -124,12 +117,6 @@ where
             }
         }
 
-        impl<T, S> Default for LinkedHashSetVisitor<T, S> {
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
         impl<'de, T, S> Visitor<'de> for LinkedHashSetVisitor<T, S>
         where
             T: Deserialize<'de> + Eq + Hash,
@@ -141,7 +128,6 @@ where
                 write!(formatter, "a sequence")
             }
 
-            #[inline]
             fn visit_seq<SA: SeqAccess<'de>>(self, mut seq: SA) -> Result<Self::Value, SA::Error> {
                 let mut values = LinkedHashSet::with_capacity_and_hasher(
                     seq.size_hint().unwrap_or(0),
@@ -156,6 +142,6 @@ where
             }
         }
 
-        deserializer.deserialize_seq(LinkedHashSetVisitor::default())
+        deserializer.deserialize_seq(LinkedHashSetVisitor::new())
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -20,6 +20,7 @@ where
     V: Serialize,
     S: BuildHasher,
 {
+    #[inline]
     fn serialize<T: Serializer>(&self, serializer: T) -> Result<T::Ok, T::Error> {
         let mut map_serializer = serializer.serialize_map(Some(self.len()))?;
         for (k, v) in self {
@@ -50,6 +51,12 @@ where
             }
         }
 
+        impl<K, V, S> Default for LinkedHashMapVisitor<K, V, S> {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
         impl<'de, K, V, S> Visitor<'de> for LinkedHashMapVisitor<K, V, S>
         where
             K: Deserialize<'de> + Eq + Hash,
@@ -77,7 +84,7 @@ where
             }
         }
 
-        deserializer.deserialize_map(LinkedHashMapVisitor::new())
+        deserializer.deserialize_map(LinkedHashMapVisitor::default())
     }
 }
 
@@ -117,6 +124,12 @@ where
             }
         }
 
+        impl<T, S> Default for LinkedHashSetVisitor<T, S> {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
         impl<'de, T, S> Visitor<'de> for LinkedHashSetVisitor<T, S>
         where
             T: Deserialize<'de> + Eq + Hash,
@@ -128,6 +141,7 @@ where
                 write!(formatter, "a sequence")
             }
 
+            #[inline]
             fn visit_seq<SA: SeqAccess<'de>>(self, mut seq: SA) -> Result<Self::Value, SA::Error> {
                 let mut values = LinkedHashSet::with_capacity_and_hasher(
                     seq.size_hint().unwrap_or(0),
@@ -142,6 +156,6 @@ where
             }
         }
 
-        deserializer.deserialize_seq(LinkedHashSetVisitor::new())
+        deserializer.deserialize_seq(LinkedHashSetVisitor::default())
     }
 }


### PR DESCRIPTION
This is the last PR of the trio of changes I wanted that I've had on my own fork for a little while now. I suspect that inlining attributes have been added over time hapazardly to random functions without really considering the affects or checking the result is desirable.

So, I've gone through and looked at every method in the public API and it's dissassembly with various opt levels ("3", "s", "z", 0) and function by function tweaked things to so that only code that needs to be inlined for performance is, and appropriate amounts are outlined at the various levels. This also included some miscellanous fixes like swapping the hasher wrapper methods to `#[inline(always)]` as not inlining generates slower *and larger* code on every single opt level outside except 0.

Generally, the changes and though process can be summed up as:
- Don't push inlining on large/complex/expensive/infrequent API methods like `clear()` or `shrink_to_fit`, call overhead for these is not a real concern but the compile drawbacks of including and recompiling those extra #[inline] functions in every codegen unit is.
- Keep/add `#[inline]` on outer API layer functions that are mostly just a shim over a couple of internal fns
- Remove it, no attribute on large internal items that implement large complex bits of logic, this results in inlining of these adapting well depending on opt level and callsite and can result in significantly less code size of crates using `hashlink`.
- Keep/add inlining for hot but small/simple internals like `hash_key` where inlining into the API caller can be highly beneficial for out of order execution reasons.
- Remove where nonsensical, like `Debug::fmt` implementations.
- Otherwise, default public generic functions to no attribute, they can still be inlined to callers in other crates without LTO since they're generics, but the inline threshold reducing effect of `#[inline]` is avoided and applied randomly just prevents LLVMs heuristics from making good decisions.

My testing of this in real world applications hasn't shown any performance regression, but has improved build time, total generated LLVM IR lines and binary size noticably on my test binary projects. I also haven't been able to create a microbenchmark that regresses on these changes. I haven't really observed any changes above statistical error.