### PR TITLE
DO NOT MERGE: build(deps): upgrade hashbrown to v0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ circle-ci = { repository = "kyren/hashlink", branch = "master" }
 serde_impl = ["serde"]
 
 [dependencies]
-hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"] }
+hashbrown = { version = "0.16", default-features = false, features = ["default-hasher", "inline-more"] }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use lru_cache::LruCache;
 /// Default hash builder, matches hashbrown's default hasher.
 ///
 /// See [`DefaultHasher`] for more details.
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct DefaultHashBuilder(hashbrown::DefaultHashBuilder);
 
 impl BuildHasher for DefaultHashBuilder {


### PR DESCRIPTION
This is intended for Mozilla consumption, rebased onto v0.10.0 so it's the only change.